### PR TITLE
Enhance zoomable images and page loading

### DIFF
--- a/components/FullscreenImage/index.tsx
+++ b/components/FullscreenImage/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import styles from "./styles.module.css";
 import Image from "next/image";
 
@@ -9,6 +9,16 @@ type Props = Omit<React.ComponentProps<typeof Image>, "alt"> & {
 
 const FullscreenImage: React.FC<Props> = (props) => {
   const [fullscreen, setFullscreen] = useState(false);
+
+  useEffect(() => {
+    const listener = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setFullscreen(false);
+    };
+    addEventListener("keydown", listener);
+    return () => {
+      removeEventListener("keydown", listener);
+    };
+  }, [fullscreen]);
 
   return (
     <>


### PR DESCRIPTION
You can now press Esc to close images

Page had to wait for response from abakus.no before loading the page. This is now handled client-side instead.