### PR TITLE
Fix error from cross origin request

### DIFF
--- a/utils/api.ts
+++ b/utils/api.ts
@@ -22,7 +22,8 @@ export const removeBlackListedEvents = (apiEvents: ApiEvent[]) =>
  */
 export const fetchEvents = async () => {
   const res = await fetch(
-    `https://lego.abakus.no/api/v1/events?date_after=${fromDate}&date_before=${toDate}`
+    `https://lego.abakus.no/api/v1/events?date_after=${fromDate}&date_before=${toDate}`,
+    { mode: "cors" }
   );
   const data: ApiResponse<ApiEvent[]> = await res.json();
   return removeBlackListedEvents(data.results);


### PR DESCRIPTION
Default mode is `same-origin`, which prevented us from fetching data from abakus.no :P

Welp it didn't fix it

See:
https://developer.mozilla.org/en-US/docs/Web/API/Request/mode
https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS