### PR TITLE
Update textual content and links

### DIFF
--- a/components/Card/index.tsx
+++ b/components/Card/index.tsx
@@ -8,17 +8,13 @@ export type CardData = {
   icon: string;
   title: string;
   description: string;
-  buttonHref?: string;
-  buttonText?: string;
+  buttons?: {
+    href: string;
+    text: string;
+  }[];
 };
 
-const Card: React.FC<CardData> = ({
-  icon,
-  title,
-  description,
-  buttonHref,
-  buttonText,
-}) => {
+const Card: React.FC<CardData> = ({ icon, title, description, buttons }) => {
   return (
     <div className={styles.card}>
       <h3 className={styles.title}>
@@ -30,11 +26,12 @@ const Card: React.FC<CardData> = ({
           <p key={line}>{line}</p>
         ))}
       </div>
-      {buttonHref && buttonText && (
-        <Button href={buttonHref} className={styles.button}>
-          {buttonText}
-        </Button>
-      )}
+      {buttons &&
+        buttons.map(({ href, text }) => (
+          <Button key={href + text} href={href} className={styles.button}>
+            {text}
+          </Button>
+        ))}
     </div>
   );
 };

--- a/components/Card/styles.module.css
+++ b/components/Card/styles.module.css
@@ -3,7 +3,6 @@
   flex-wrap: wrap;
   gap: 20px;
   margin-top: 2em;
-  justify-content: space-between;
 }
 
 .card {

--- a/components/EventsListView/index.tsx
+++ b/components/EventsListView/index.tsx
@@ -70,10 +70,14 @@ const EventsListView: React.FC<EventsListViewProps> = ({
               <EventItem key={event.id} event={event} />
             ))
           ) : (
-            <p>Ingen abakus-arrangementer</p>
+            <p>Ingen fadderperiode-arrangementer</p>
           )}
         </div>
       ))}
+      <p>
+        Se alle Abakus sine arrangementer på{" "}
+        <a href="https://abakus.no/events">abakus.no/events</a>
+      </p>
     </div>
   );
 };

--- a/components/FaqContent/index.tsx
+++ b/components/FaqContent/index.tsx
@@ -24,6 +24,11 @@ const FaqContent: React.FC = () => {
           </details>
         </div>
       ))}
+      <p>
+        Lurer du på noe mer? Send en mail til Webkom på{" "}
+        <a href="mailto:webkom@abakus.no">webkom@abakus.no</a>, så hjelper vi
+        deg finne svaret - og legger det ut her så andre også kan finne det.
+      </p>
     </InfoSectionWrapper>
   );
 };
@@ -41,13 +46,60 @@ const faqItems: FaqItem[] = [
     title: "Hva er en linjeforening?",
     key: "linjeforening",
     content:
-      "En linjeforening er en forening av og for studentene som går ett eller flere studier.",
+      "En linjeforening er en forening av og for studentene som går ett eller flere studier. I Trondheim finnes det derfor veldig mange forskjellige linjeforeninger - men du forholder deg hovedsakelig kun til den studieretningen din tilhører.",
   },
   {
     title: "Hva består Abakus av?",
     key: "abakus",
-    content:
-      "Abakus består av omtrent 1000 studenter, fra Komtek og Data.\nInnad i disse har vi et Hovedstyre, 10 komitéer, 1 revy, 5 undergrupper og masse interessegrupper.",
+    content: (
+      <div>
+        <p>Abakus består av omtrent 1000 studenter, fra Komtek og Data.</p>
+        <p>
+          Innad i disse har vi et Hovedstyre, 10 komitéer, 1 revy, 5
+          undergrupper og masse interessegrupper.
+        </p>
+        <br />
+        <p>
+          På <a href="https://abakus.no/pages/info-om-abakus">Om Abakus</a>{" "}
+          finner du det aller meste av informasjon om linjeforeningen vår. Under
+          har vi lenket til noen nyttige steder å starte om du er nysgjerrig.
+        </p>
+        <p>
+          <a href="https://abakus.no/pages/styrer/12">Les mer om Hovedstyret</a>
+        </p>
+        <p>
+          <a href="https://abakus.no/pages/komiteer/4">
+            Les mer om komitéene (siden lenker til Arrangementskomitéen, se i
+            menyen for å finne resten av komitéene)
+          </a>
+        </p>
+        <p>
+          <a href="https://abakus.no/pages/grupper/104-revyen">
+            Les mer om revyen
+          </a>
+        </p>
+        <p>
+          <a href="https://abakus.no/pages/grupper/31-undergrupper">
+            Les mer om undergrupper
+          </a>
+        </p>
+        <p>
+          <a href="https://abakus.no/pages/grupper/39-praktisk-informasjon">
+            Les mer om interessegrupper
+          </a>
+        </p>
+        <p>
+          <a href="https://abakus.no/interest-groups">
+            Finn alle interessegruppene
+          </a>
+          <br />
+          NB: Interessegruppene pleier å kommunisere via Facebook - dette står
+          det informasjon om inne på siden til den enkelte interessegruppen. Om
+          du skal finne dem på Facebook skal alle gruppene innholde &quot;Abakus
+          interessegruppe&quot; i navnet for å være lettere å søke etter.
+        </p>
+      </div>
+    ),
   },
   {
     title: "Hvordan lage bruker på abakus.no?",
@@ -70,7 +122,60 @@ const faqItems: FaqItem[] = [
   {
     title: "Kontaktinformasjon",
     key: "kontakt",
-    content:
-      "Leder Abakus: Henriette Bjørheim, 915 86 737, henriette.bjorheim@abakus.no\nLeder Arrangementskomiteen til Abakus: Håkon Hoelsæter, 479 55 802, hakon.hoelsaeter@abakus.no\nAnsvarlig for kommunikasjon med faddere og fadderbarn: Kaisa Øyre Larsen, 916 41 758, kaisa.larsen@abakus.no \nAnsvarlig for kommunikasjon med faddere og fadderbarn: Ingrid Talseth Singstad, 403 28 322, ingrid.singstad@abakus.no",
+    content: (
+      <div>
+        <p>
+          Leder av Abakus:
+          <br />
+          Henriette Bjørheim, 915 86 737, henriette.bjorheim@abakus.no
+        </p>
+        <p>
+          Leder av Arrangementskomiteen til Abakus:
+          <br />
+          Håkon Hoelsæter, 479 55 802, hakon.hoelsaeter@abakus.no
+        </p>
+        <p>
+          Ansvarlig for kommunikasjon med faddere og fadderbarn:
+          <br />
+          Kaisa Øyre Larsen, 916 41 758, kaisa.larsen@abakus.no
+        </p>
+        <p>
+          Ansvarlig for kommunikasjon med faddere og fadderbarn:
+          <br />
+          Ingrid Talseth Singstad, 403 28 322, ingrid.singstad@abakus.no
+        </p>
+      </div>
+    ),
+  },
+  {
+    title: "Tips & triks på abakus.no",
+    key: "tips",
+    content: (
+      <div>
+        <h3>Få Abakus-arrangementer rett i kalenderen din</h3>
+        <p>
+          I studielivet skjer det mye rart, og da er det nyttig å ha kontroll på
+          hva som skjer når!
+        </p>
+        <p>
+          Om du går inn på{" "}
+          <a href="https://abakus.no/events">abakus.no/events</a> på PC og blar
+          helt nederst på siden, får du alternativene mellom tre mulige
+          kalendere. Enten alle arrangementer, alle registreringstidspunkter
+          (påmeldingstidspunkt) eller dine møter og favorittarrangementer.
+        </p>
+        <p>
+          De to første kan fort bli overvelmende, men den siste inkluderer alle
+          arrangementer der du er påmeldt eller på venteliste, og de du manuelt
+          har lagt til som favoritt (ved å trykke på stjernen ved siden av
+          navnet til arrangementet på abakus.no).
+        </p>
+        <p>
+          Ved å trykke på lenkene kan du enten få kalenderene rett inn i Google
+          Kalender eller hvilken som helst annen kalender som støtter iCalendar
+          (så godt som alle).
+        </p>
+      </div>
+    ),
   },
 ];

--- a/components/Header/HeaderCards.tsx
+++ b/components/Header/HeaderCards.tsx
@@ -1,4 +1,4 @@
-import Card, { CardWrapper } from "@/components/Card";
+import Card, { CardData, CardWrapper } from "@/components/Card";
 import styles from "./styles.module.css";
 import InfoSectionWrapper from "@/components/InfoSectionWrapper";
 
@@ -6,18 +6,15 @@ const HeaderCards: React.FC = () => {
   return (
     <InfoSectionWrapper className={styles.header}>
       <CardWrapper>
-        {cardData.map(
-          ({ title, icon, description, buttonHref, buttonText }) => (
-            <Card
-              key={title}
-              icon={icon}
-              title={title}
-              description={description}
-              buttonHref={buttonHref}
-              buttonText={buttonText}
-            />
-          )
-        )}
+        {cardData.map(({ title, icon, description, buttons }) => (
+          <Card
+            key={title}
+            icon={icon}
+            title={title}
+            description={description}
+            buttons={buttons}
+          />
+        ))}
       </CardWrapper>
     </InfoSectionWrapper>
   );
@@ -25,31 +22,57 @@ const HeaderCards: React.FC = () => {
 
 export default HeaderCards;
 
-const cardData = [
+const cardData: CardData[] = [
+  {
+    title: "Facebook-gruppe for nye studenter",
+    icon: "logo-facebook",
+    description:
+      "Det meste av informasjon til nye studenter kommer via en egen Facebook-gruppe, som det er anbefalt at du blir med i med en gang!",
+    buttons: [
+      {
+        href: "https://www.facebook.com/groups/280352384450789/",
+        text: "Gå til Facebook-gruppe",
+      },
+    ],
+  },
   {
     title: "Lag bruker på abakus.no",
     icon: "person",
     description:
       "Meld deg på arrangementer og følg med på hva som skjer i Abakus!",
-    buttonHref:
-      "https://www.notion.so/Hvordan-lage-bruker-p-Abakus-no-17be056689194337a1d44865f577d536",
-    buttonText: "Gå til guide",
+    buttons: [
+      {
+        href: "https://www.notion.so/Hvordan-lage-bruker-p-Abakus-no-17be056689194337a1d44865f577d536",
+        text: "Gå til guide",
+      },
+    ],
   },
   {
     title: "Bli med på Slack",
     icon: "logo-slack",
     description:
       "Hold kontakten med resten av Abakus! Her har vi alt fra event-reminders, kjøp og salg, memes og forum for å finne sted å bo.",
-    buttonHref:
-      "https://join.slack.com/t/abakus-ntnu/shared_invite/zt-19m96d1du-WoVE99K20g5iUeKaTGSVxw",
-    buttonText: "Åpne Slack",
+    buttons: [
+      {
+        href: "https://join.slack.com/t/abakus-ntnu/shared_invite/zt-19m96d1du-WoVE99K20g5iUeKaTGSVxw",
+        text: "Åpne Slack",
+      },
+    ],
   },
   {
-    title: "Meldeskjema",
+    title: "Kontaktskjema og varsling",
     icon: "chatbox",
     description:
-      "Har du blitt utsatt for en ubehagelig hendelse? Meld fra gjennom meldeskjemaet vårt! \nDu kan være helt anonym dersom du ønsker det.",
-    buttonHref: "https://abakus.no/contact",
-    buttonText: "Gå til meldeskjema",
+      "Har du noe du vil si ifra om? Meld fra gjennom kontaktskjemaet vårt! Vi har også en varslingsportal for ubehagelige hendelser og avvik. \nDu kan være helt anonym dersom du ønsker det.",
+    buttons: [
+      {
+        href: "https://abakus.no/contact",
+        text: "Gå til kontaktskjema",
+      },
+      {
+        href: "https://avvik.abakus.no",
+        text: "Gå til varslingsportal",
+      },
+    ],
   },
 ];

--- a/components/InfoSectionFP/index.tsx
+++ b/components/InfoSectionFP/index.tsx
@@ -7,6 +7,15 @@ const InfoSectionFP = () => {
     <InfoSectionWrapper id="fadderperioden" className={styles.fpInfo}>
       <h2 className={styles.title}>Fadderperioden</h2>
       <p>
+        NB! Dette er en plan fra linjeforeningen din, Abakus, som ikke
+        inkluderer alle detaljer om det obligatoriske opplegget fra
+        instituttet/fakultetet. For å være sikker på at du ikke går glipp av
+        noe, sjekk <a href="https://www.ntnu.no/studier/mtkom">denne siden</a>{" "}
+        hvis du skal gå Kommunikasjonsteknologi og digital sikkerhet (Komtek)
+        eller <a href="https://www.ntnu.no/studier/mtdt">denne</a> hvis du skal
+        gå Datateknologi (Data).
+      </p>
+      <p>
         Fadderperioden for datateknologi og kommunikasjonsteknologi er arrangert
         av Abakus.
       </p>

--- a/components/InfoSectionPreparation/index.tsx
+++ b/components/InfoSectionPreparation/index.tsx
@@ -14,18 +14,15 @@ const InfoSectionPreparation = () => {
         hjemmefra
       </p>
       <CardWrapper>
-        {cardData.map(
-          ({ title, icon, description, buttonHref, buttonText }) => (
-            <Card
-              key={title}
-              icon={icon}
-              title={title}
-              description={description}
-              buttonHref={buttonHref}
-              buttonText={buttonText}
-            />
-          )
-        )}
+        {cardData.map(({ title, icon, description, buttons }) => (
+          <Card
+            key={title}
+            icon={icon}
+            title={title}
+            description={description}
+            buttons={buttons}
+          />
+        ))}
       </CardWrapper>
     </InfoSectionWrapper>
   );
@@ -35,27 +32,39 @@ export default InfoSectionPreparation;
 
 const cardData: CardData[] = [
   {
-    title: "Betal semesteravgift",
-    icon: "cash",
-    description:
-      "Etter du har fått plass på studiet kan du betale semesteravgift på studentweb, det trenger du for å få studentmail+++, så det er greit å gjøre så fort som mulig",
-    buttonHref: "https://ntnu.no/studentweb",
-    buttonText: "Gå til studentweb",
-  },
-  {
     title: "Pakkeliste",
     icon: "bag",
     description:
       "Vi har samlet våre beste tips til hva du burde pakke med deg når du reiser til Trondheim!",
-    buttonHref: "/faq#pakkeliste",
-    buttonText: "Les mer",
+    buttons: [
+      {
+        href: "/faq#pakkeliste",
+        text: "Les mer",
+      },
+    ],
+  },
+  {
+    title: "Betal semesteravgift",
+    icon: "cash",
+    description:
+      "Etter du har fått plass på studiet kan du betale semesteravgift på studentweb, det trenger du for å få studentmail+++, så det er greit å gjøre så fort som mulig",
+    buttons: [
+      {
+        href: "https://ntnu.no/studentweb",
+        text: "Gå til studentweb",
+      },
+    ],
   },
   {
     title: "Kontaktinformasjon",
     icon: "call",
     description:
       "Her har kan du finne kontaktinformasjonen til diverse personer i Abakus dersom du lurer på noe",
-    buttonHref: "/faq#kontakt",
-    buttonText: "Les mer",
+    buttons: [
+      {
+        href: "/faq#kontakt",
+        text: "Les mer",
+      },
+    ],
   },
 ];

--- a/components/InfoSectionStudy/index.tsx
+++ b/components/InfoSectionStudy/index.tsx
@@ -19,18 +19,15 @@ const InfoSectionStudy = () => {
         sjekk ut <Link href={"https://nyitrondheim.no"}>nyitrondheim.no</Link>.
       </p>
       <CardWrapper>
-        {cardData.map(
-          ({ title, icon, description, buttonHref, buttonText }) => (
-            <Card
-              key={title}
-              icon={icon}
-              title={title}
-              description={description}
-              buttonHref={buttonHref}
-              buttonText={buttonText}
-            />
-          )
-        )}
+        {cardData.map(({ title, icon, description, buttons }) => (
+          <Card
+            key={title}
+            icon={icon}
+            title={title}
+            description={description}
+            buttons={buttons}
+          />
+        ))}
       </CardWrapper>
     </InfoSectionWrapper>
   );
@@ -44,31 +41,71 @@ const cardData: CardData[] = [
     icon: "ellipse",
     description:
       "Bedriftspresentasjoner, fester, kurs, lavterskel arrangementer, artikler, jobbannonser og mye mer!",
-    buttonHref: "https://abakus.no",
-    buttonText: "Gå til abakus.no",
+    buttons: [
+      {
+        href: "https://abakus.no",
+        text: "Gå til abakus.no",
+      },
+    ],
   },
   {
     title: "Instabart",
     icon: "link",
     description:
       "Du finner en rask samling av lenker til ting du har bruk for på instabart.no",
-    buttonHref: "https://instabart.no",
-    buttonText: "Gå til instabart",
+    buttons: [
+      {
+        href: "https://instabart.no",
+        text: "Gå til instabart",
+      },
+    ],
+  },
+  {
+    title: "Ababart",
+    icon: "link",
+    description:
+      "Overskt over de forskjellige tjenestene som er laget av og for Abakus på aba.wtf",
+    buttons: [
+      {
+        href: "https://aba.wtf",
+        text: "Gå til aba.wtf",
+      },
+    ],
   },
   {
     title: "Data-start",
     icon: "link",
     description:
-      "Lignende instabart, men er litt nyere og rettet mot studenter innen IT.",
-    buttonHref: "https://data-start.vercel.app",
-    buttonText: "Gå til data-start",
+      "Lignende instabart, men er litt nyere og rettet mot studenter innen IT",
+    buttons: [
+      {
+        href: "https://data-start.vercel.app",
+        text: "Gå til data-start",
+      },
+    ],
+  },
+  {
+    title: "Tips og triks abakus.no",
+    icon: "build",
+    description:
+      "Tips&triks som kan gjøre det enklere å holde kontroll på hva som skjer i linjeforeningen",
+    buttons: [
+      {
+        href: "/faq#tips",
+        text: "Les mer",
+      },
+    ],
   },
   {
     title: "Verv",
     icon: "people",
     description:
       "Omtrent mot slutten av fadderperioden finnes det masse verv som har opptak. I Abakus er det opptak til Komitéer og revy, men det er også mye som skjer på Samfundet, UKA, NTNUI, +++",
-    buttonHref: "https://nyitrondheim.no/verv-deg",
-    buttonText: "Les mer på nyitrondheim.no",
+    buttons: [
+      {
+        href: "https://nyitrondheim.no/verv-deg",
+        text: "Les mer på nyitrondheim.no",
+      },
+    ],
   },
 ];

--- a/components/InfoSectionTrondheim/index.tsx
+++ b/components/InfoSectionTrondheim/index.tsx
@@ -1,4 +1,4 @@
-import Card, { CardWrapper } from "@/components/Card";
+import Card, { CardData, CardWrapper } from "@/components/Card";
 import Link from "next/link";
 import InfoSectionWrapper from "../InfoSectionWrapper";
 import styles from "./styles.module.css";
@@ -16,12 +16,13 @@ const InfoSectionTrondheim: React.FC = () => {
         <Link href={"https://nyitrondheim.no"}>nyitrondheim.no</Link>.
       </p>
       <CardWrapper>
-        {cardData.map(({ title, icon, description }) => (
+        {cardData.map(({ title, icon, description, buttons }) => (
           <Card
             key={title}
             icon={icon}
             title={title}
             description={description}
+            buttons={buttons}
           />
         ))}
       </CardWrapper>
@@ -31,29 +32,54 @@ const InfoSectionTrondheim: React.FC = () => {
 
 export default InfoSectionTrondheim;
 
-const cardData = [
+const cardData: CardData[] = [
   {
-    title: "Abakus-kontoret",
-    icon: "cafe",
+    title: "Immatrikulering",
+    icon: "school",
     description:
-      "I Abakus har vi vårt eget kontor på Realfagsbygget! Her kan du slappe av med Smash/Mariokart, spise lunsj eller kjøpe noe billig snacks fra kiosken vår Snack Overflow",
-  },
-  {
-    title: "Komtek-loungen",
-    icon: "tv",
-    description:
-      "Kommunikasjonsteknologi sitt eget hvileområde, med kjøkkenkrok, sofa, bordtennisbord og TV",
+      "Immatrikuleringen er velkomstseremonien til NTNU. Du kan lese mer om det, samt obligatorisk opplegg, på NTNU og instituttene sine nettsider",
+    buttons: [
+      {
+        href: "https://www.ntnu.no/studier/mtdt",
+        text: "Info for Datateknologi",
+      },
+      {
+        href: "https://www.ntnu.no/studier/mtkom",
+        text: "Info for Kommunikasjonsteknologi",
+      },
+    ],
   },
   {
     title: "A3",
     icon: "business",
     description:
       "A3 (3. etasje på A-blokka i Realfagsbygget) er der kontoret vårt er, i tillegg til bordtennisbord og leserom der du garantert finner mange av medstudentene dine!",
+    buttons: [
+      { href: "https://link.mazemap.com/DNpjwD7X", text: "Finn med Mazemap" },
+    ],
   },
   {
-    title: "Immatrikulering",
-    icon: "school",
+    title: "Abakus-kontoret",
+    icon: "cafe",
     description:
-      "Immatrikuleringen er velkomstseremonien til NTNU. Du kan lese mer om det på NTNU og instituttene sine nettsider",
+      "I Abakus har vi vårt eget kontor på Realfagsbygget! Her kan du slappe av med Smash/Mariokart, spise lunsj eller kjøpe noe billig snacks fra kiosken vår Snack Overflow",
+    buttons: [
+      { href: "https://link.mazemap.com/3IOdPx0q", text: "Finn med Mazemap" },
+    ],
+  },
+  {
+    title: "Komtek-loungen",
+    icon: "tv",
+    description:
+      "Kommunikasjonsteknologi sitt eget hvileområde, med kjøkkenkrok, sofa, bordtennisbord og TV",
+    buttons: [
+      { href: "https://link.mazemap.com/IXgO7HUW", text: "Finn med Mazemap" },
+    ],
+  },
+  {
+    title: "Teknostart",
+    icon: "laptop",
+    description:
+      "Teknostart er det obligatoriske faglige oppstarts-opplegget til instituttene. Her vil dere jobbe med faglig relevante ting i grupper, for å få en god start på studiehverdagen. Dette vil foregå på dagtid, tirsdag-fredag første uken.",
   },
 ];

--- a/pages/events.tsx
+++ b/pages/events.tsx
@@ -42,6 +42,16 @@ export const Events: NextPage<EventsProps> = ({ dayDescriptions }) => {
       <InfoSectionWrapper>
         <h2 className={styles.title}>Fadderperioden</h2>
         <p>
+          NB! Dette er en plan fra linjeforeningen din, Abakus, som ikke
+          inkluderer alle detaljer om det obligatoriske opplegget fra
+          instituttet/fakultetet. For å være sikker på at du ikke går glipp av
+          noe, sjekk <a href="https://www.ntnu.no/studier/mtkom">denne siden</a>{" "}
+          hvis du skal gå Kommunikasjonsteknologi og digital sikkerhet (Komtek)
+          eller <a href="https://www.ntnu.no/studier/mtdt">denne</a> hvis du
+          skal gå Datateknologi (Data).
+        </p>
+        <br />
+        <p>
           Fadderperioden for datateknologi og kommunikasjonsteknologi er
           arrangert av Abakus.
         </p>
@@ -52,10 +62,10 @@ export const Events: NextPage<EventsProps> = ({ dayDescriptions }) => {
           <a href="mailto:arrkom@abakus.no">arrkom@abakus.no</a> for å få en
           faddergruppe.
         </p>
-        <p>&nbsp; </p>
+        <br />
         <p>Oppmøte for Datateknologi: TBD</p>
         <p>Oppmøte for Kommunikasjonsteknologi: TBD</p>
-        <p>&nbsp; </p>
+        <br />
         <p>
           Facebook-gruppe for nye abakuler{" "}
           <Link
@@ -78,7 +88,7 @@ export const Events: NextPage<EventsProps> = ({ dayDescriptions }) => {
       </InfoSectionWrapper> */}
       <InfoSectionWrapper>
         {isLoading ? (
-          <p>Laster inn Abakus-arrangement ...</p>
+          <p>Laster inn fadderperiode-arrangementer ...</p>
         ) : events.length ? (
           <EventsListView events={events} dayDescriptions={dayDescriptions} />
         ) : (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -15,8 +15,8 @@ export default function Home() {
       <HeaderCards />
       <InfoSectionPreparation />
       <InfoSectionTrondheim />
-      <InfoSectionStudentPub />
       <InfoSectionFP />
+      <InfoSectionStudentPub />
       <InfoSectionStudy />
     </>
   );


### PR DESCRIPTION
Add option to make cards contain multiple links.

Added a couple of new cards (teknostart, facebook-gruppe)

Most of the changes are textual, so it should be enough to visit the preview-deployment or read the code. The preview-deployment still cannot display the entire events-page, but I have done very few changes there so it should be fine.