### PR TITLE
Use abakus red for navbar and preparation section

### DIFF
--- a/components/InfoSectionPreparation/styles.module.css
+++ b/components/InfoSectionPreparation/styles.module.css
@@ -1,7 +1,7 @@
 .preparationSection {
-  background-color: var(--red-1);
+  background-color: var(--abakus-dark-red);
   color: white;
-  box-shadow: 0 0 10px -5px var(--red-1);
+  box-shadow: 0 0 10px -5px var(--abakus-dark-red);
 }
 
 .title {

--- a/components/Navbar/styles.module.css
+++ b/components/Navbar/styles.module.css
@@ -1,5 +1,5 @@
 .navbar {
-  background-color: var(--red-1);
+  background-color: var(--abakus-dark-red);
   padding: 1rem 1.5rem;
   color: white;
   font-weight: 600;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -21,6 +21,7 @@ a {
 :root {
   --red-1: #c0392b;
   --abakus-red: #e21617;
+  --abakus-dark-red: #b21c17;
   --labamba-yellow: #ffcb20;
   --day-description: #ffe6e3;
 


### PR DESCRIPTION
I'm not a huge fan of the orangered we use on the page right now (--red-1). The Abakus-red colors are a bit bright and not perfect for large UI elements, but I think the Abakus dark-red looks better and more on brand. 

|Before|After|
|-|-|
|<img width="1622" alt="Screenshot 2023-08-09 at 22 21 10" src="https://github.com/webkom/nyiabakus/assets/8343002/9de8cd7d-b9b7-46c0-9bd0-cdac206751f2">|<img width="1622" alt="Screenshot 2023-08-09 at 22 19 35" src="https://github.com/webkom/nyiabakus/assets/8343002/54d56024-6ab4-4e84-a639-938e2724eb25">|
