### PR TITLE
Move MFP to separate site

### DIFF
--- a/components/Navbar/index.tsx
+++ b/components/Navbar/index.tsx
@@ -8,6 +8,7 @@ const Navbar = () => {
         <div className={styles.navLinksWrapper}>
           <Link href={"/"}>Startside</Link>
           <Link href={"/events"}>Fadderperioden</Link>
+          <Link href={"/masterfadderperioden"}>Masterfadderperioden</Link>
           <Link href={"/faq"}>FAQ</Link>
         </div>
         <div className={styles.logoWrapper}>

--- a/components/Navbar/styles.module.css
+++ b/components/Navbar/styles.module.css
@@ -27,15 +27,17 @@
     gap: 1.5rem;
   }
 
-  .navLinksWrapper, .logoWrapper {
+  .navLinksWrapper,
+  .logoWrapper {
     justify-content: center;
   }
 }
 
 .navLinksWrapper {
   display: flex;
+  flex-wrap: wrap;
   flex-grow: 1;
-  gap: 2em;
+  gap: 1em 2em;
 }
 
 .logoWrapper {

--- a/pages/masterfadderperioden.tsx
+++ b/pages/masterfadderperioden.tsx
@@ -6,7 +6,6 @@ import { deserializeEvents, fetchEvents } from "@/utils/api";
 import { NextPage } from "next";
 import { ApiEvent } from "@/utils/types";
 import Link from "next/link";
-import FullscreenImage from "@/components/FullscreenImage";
 import { createClient, groq } from "next-sanity";
 import { TypedObject } from "sanity";
 import { FPGroups } from "@/schemas/dayDescription";
@@ -29,7 +28,7 @@ export const Events: NextPage<EventsProps> = ({ dayDescriptions }) => {
   useEffect(() => {
     (async () => {
       try {
-        const apiEvents = await fetchEvents("fp");
+        const apiEvents = await fetchEvents("mfp");
         setApiEvents(apiEvents);
       } catch (error) {
         console.error(error);
@@ -42,11 +41,11 @@ export const Events: NextPage<EventsProps> = ({ dayDescriptions }) => {
   return (
     <>
       <InfoSectionWrapper contentClassName={styles.fpInfo}>
-        <h2 className={styles.title}>Fadderperioden</h2>
+        <h2 className={styles.title}>Masterfadderperioden</h2>
         <p>
-          Fadderperioden er for alle som begynner på{" "}
-          <b>5-årig integrert master</b>. Begynner du på 2-årig master? Gå til{" "}
-          <Link href={"/masterfadderperioden"}>Masterfadderperioden</Link>.
+          Masterfadderperioden er for alle som begynner på <b>2-årig master</b>.
+          Begynner du på 5-årig integrert master? Gå til{" "}
+          <Link href={"/events"}>Fadderperioden</Link>.
         </p>
         <p>
           NB! Dette er en plan fra linjeforeningen din, Abakus, som ikke
@@ -54,14 +53,13 @@ export const Events: NextPage<EventsProps> = ({ dayDescriptions }) => {
           instituttet/fakultetet. For å være sikker på at du ikke går glipp av
           noe, sjekk ut NTNU sin side som hører til ditt studie;
           <br />
-          <a href="https://www.ntnu.no/studier/mtkom">
-            5-årig: Kommunikasjonsteknologi og digital sikkerhet (Komtek)
-          </a>
+          <a href="https://www.ntnu.no/studier/mstcnns">
+            2-årig: Digital Infrastructure and Cyber Security (Komtek)
+          </a>{" "}
           <br />
-          <a href="https://www.ntnu.no/studier/mtdt">
-            5-årig: Datateknologi (Data)
+          <a href="https://www.ntnu.no/studier/midt">
+            2-årig: Datateknologi (Data)
           </a>
-          <br />
         </p>
         <p>
           Fadderperioden for Datateknologi og Kommunikasjonsteknologi er
@@ -72,21 +70,17 @@ export const Events: NextPage<EventsProps> = ({ dayDescriptions }) => {
           For å bli med må du møte opp på immatrikuleringen, hvor du blir
           plassert i en faddergruppe og får mer informasjon. Hvis du ikke får
           møtt opp, send en epost til{" "}
-          <a href="mailto:fadderperioden@abakus.no">fadderperioden@abakus.no</a>{" "}
+          <a href="mailto:masterfadderperioden@abakus.no">
+            masterfadderperioden@abakus.no
+          </a>{" "}
           for å få en faddergruppe.
         </p>
+        <p>Oppmøte for Datateknologi: TBD</p>
+        <p>Oppmøte for Digital Infrastructure and Cyber Security: TBD</p>
         <p>
-          Oppmøte for Datateknologi: Mandag 14. August 12:00 på{" "}
-          <Link href={"https://link.mazemap.com/gqncrU4T"}>Kjel 5</Link>
-        </p>
-        <p>
-          Oppmøte for Kommunikasjonsteknologi: Mandag 14. August 10:00 på{" "}
-          <Link href={"https://link.mazemap.com/Kpd4nMvI"}>EL2</Link>
-        </p>
-        <p>
-          Facebook-gruppe for nye abakuler på 5-årig integrert master{" "}
+          Facebook-gruppe for nye abakuler på 2-årig master{" "}
           <Link
-            href={"https://www.facebook.com/groups/280352384450789/"}
+            href={"https://www.facebook.com/groups/175376555487442/"}
             target={"_blank"}
           >
             finner du her
@@ -94,15 +88,6 @@ export const Events: NextPage<EventsProps> = ({ dayDescriptions }) => {
           .
         </p>
       </InfoSectionWrapper>
-      {/* <InfoSectionWrapper>
-        <FullscreenImage
-          src="/uc.jpg"
-          alt="Under konstruksjon"
-          width={530}
-          height={355}
-          className={styles.fullscreenImage}
-        />
-      </InfoSectionWrapper> */}
       <InfoSectionWrapper>
         {!isLoading && events.length == 0 && dayDescriptions.length !== 0 && (
           <p>
@@ -123,6 +108,7 @@ export const Events: NextPage<EventsProps> = ({ dayDescriptions }) => {
           isLoadingEvents={isLoading}
           events={events}
           dayDescriptions={dayDescriptions}
+          expandDayDescriptionsByDefault
         />
       </InfoSectionWrapper>
     </>
@@ -144,7 +130,7 @@ export async function getStaticProps() {
   let dayDescriptions: DayDescription[] = [];
   try {
     dayDescriptions = await client.fetch(
-      groq`*[_type == "fpDayDescription"] | order(date asc)`
+      groq`*[_type == "mfpDayDescription"] | order(date asc)`
     );
   } catch (e) {}
   return {

--- a/schemas/dayDescription.ts
+++ b/schemas/dayDescription.ts
@@ -3,10 +3,10 @@ export const FPGroups = [
   { title: "5-årig", value: "5_YEAR" },
 ];
 
-export default {
+const baseSchema = {
   name: "dayDescription",
   type: "document",
-  title: "Day Description",
+  title: "Fadderperioden",
   preview: {
     select: {
       date: "date",
@@ -23,11 +23,7 @@ export default {
         dateDisplayString.charAt(0).toUpperCase() + dateDisplayString.slice(1);
 
       return {
-        title:
-          (selection.fpGroup
-            ? FPGroups.find((fpg) => fpg.value === selection.fpGroup)?.title +
-              " "
-            : "") + capitalizedDateString,
+        title: capitalizedDateString,
       };
     },
   },
@@ -43,14 +39,29 @@ export default {
       type: "array",
       of: [{ type: "block" }],
     },
+  ],
+  orderings: [
     {
-      title: "Faddergruppe",
-      name: "fpGroup",
-      type: "string",
-      options: {
-        list: FPGroups.map(({ title, value }) => ({ title, value })),
-        layout: "select",
-      },
+      title: "Dato stigende",
+      name: "dateAsc",
+      by: [{ field: "date", direction: "asc" }],
+    },
+    {
+      title: "Dato synkende",
+      name: "dateDesc",
+      by: [{ field: "date", direction: "desc" }],
     },
   ],
+};
+
+export const FPSchema = {
+  ...baseSchema,
+  name: "fpDayDescription",
+  title: "Fadderperioden",
+};
+
+export const MFPSchema = {
+  ...baseSchema,
+  name: "mfpDayDescription",
+  title: "Masterfadderperioden",
 };

--- a/schemas/index.ts
+++ b/schemas/index.ts
@@ -1,3 +1,3 @@
-import dayDescription from "./dayDescription";
+import { FPSchema, MFPSchema } from "./dayDescription";
 
-export const schemaTypes = [dayDescription];
+export const schemaTypes = [FPSchema, MFPSchema];

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -5,6 +5,10 @@ const toDate = "2023-09-04"; // One day after Immball
 
 // For events in the time period that are not included in FP
 const blackListedEventIds: number[] = [3446, 3420, 3452];
+const specificBlackListedEventIds = {
+  fp: [3461],
+  mfp: [3460, 3448, 3433, 3435, 3449, 3436, 3453, 3432, 3438, 3441],
+};
 
 /**
  * Remove events from the list that are not included in FP
@@ -12,20 +16,29 @@ const blackListedEventIds: number[] = [3446, 3420, 3452];
  * @param apiEvents Complete list of ApiEvent objects
  * @returns Filtered list of ApiEvent objects
  */
-export const removeBlackListedEvents = (apiEvents: ApiEvent[]) =>
-  apiEvents.filter((apiEvent) => !blackListedEventIds.includes(apiEvent.id));
+export const removeBlackListedEvents = (
+  apiEvents: ApiEvent[],
+  type: keyof typeof specificBlackListedEventIds
+) =>
+  apiEvents.filter(
+    (apiEvent) =>
+      !blackListedEventIds.includes(apiEvent.id) &&
+      !specificBlackListedEventIds[type].includes(apiEvent.id)
+  );
 
 /**
  * Fetch list of events from LEGO API
  *
  * @returns List of deserialized Event objects
  */
-export const fetchEvents = async () => {
+export const fetchEvents = async (
+  type: keyof typeof specificBlackListedEventIds
+) => {
   const res = await fetch(
     `https://lego.abakus.no/api/v1/events?date_after=${fromDate}&date_before=${toDate}`
   );
   const data: ApiResponse<ApiEvent[]> = await res.json();
-  return removeBlackListedEvents(data.results);
+  return removeBlackListedEvents(data.results, type);
 };
 
 /**


### PR DESCRIPTION
It felt a bit misleading to have all the daydescriptions on the same site - as I do not think they share all the events from abakus.no, so I moved them over to a separate site.

Did a quick guess to see what events should and should not be in MFP, but I'll ask the MFP gang to verify later.

Heaps of duplicate code in the new materfadderperioden file, but it can be refactored later

Changes

* Add blacklists for events for FP and MFP
* Display DayDescriptions before events have been loaded
* Separate schemas for DayDescription for FP and MFP
* Add sorting of DayDescriptions in Sanity
