### PR TITLE
Remove info and links from 2023, komtek->cybdat

### DIFF
--- a/components/EventsListView/index.tsx
+++ b/components/EventsListView/index.tsx
@@ -1,15 +1,17 @@
+import { DayDescription } from "@/pages/fadderperioden";
+import { isTBD } from "@/utils/api";
 import {
   dateToDayString,
   isSameCalendarDate,
   numberOfDaysBetweenDates,
 } from "@/utils/date";
 import { Event } from "@/utils/types";
+import { PortableText, PortableTextComponents } from "@portabletext/react";
+import Link from "next/link";
 import { useMemo } from "react";
+import CollapsibleItem from "./CollapsibleItem";
 import EventItem from "./EventItem";
 import styles from "./styles.module.css";
-import { PortableText, PortableTextComponents } from "@portabletext/react";
-import CollapsibleItem from "./CollapsibleItem";
-import { DayDescription } from "@/pages/events";
 
 type EventsListViewProps = {
   events: Event[];
@@ -93,6 +95,29 @@ const EventsListView: React.FC<EventsListViewProps> = ({
       };
     });
   }, [events, dayDescriptions]);
+
+  if (isTBD)
+    return (
+      <p>Programmet for fadderperioden vil publiseres her når det er ferdig</p>
+    );
+
+  if (!isLoadingEvents && events.length === 0 && dayDescriptions.length === 0)
+    return (
+      <p>
+        Klarte ikke hente arrangementer. Hvis problemet vedvarer, sjekk{" "}
+        <Link href={"https://abakus.no"}>abakus.no</Link> eller facebook-gruppa
+        for nye studenter.
+      </p>
+    );
+
+  if (!isLoadingEvents && events.length === 0)
+    return (
+      <p>
+        Klarte ikke hente arrangementer fra abakus.no. Du kan fortsatt finne
+        alle arrangementene på <Link href={"https://abakus.no"}>abakus.no</Link>
+        .
+      </p>
+    );
 
   return (
     <div className={styles.eventsList}>

--- a/components/FaqContent/index.tsx
+++ b/components/FaqContent/index.tsx
@@ -68,7 +68,7 @@ const generalFaqItems: FaqItem[] = [
     title: "Pakkeliste til Fadderperioden",
     key: "pakkeliste",
     content:
-      "Til Fadderperioden er det en del arrangementer som har tema, som det kan være smart å tenke på før du reiser hjemmefra.\n\n- Piratkostyme (gjelder ikke 2-årig master)\n- Hvitt laken uten stretch\n- Outfit til Ops, jeg kom feil\n- Hippieklær\n- Bevegelige klær som tåler å bli våte\n- Dress/Gallakjole",
+      "Til Fadderperioden er det en del arrangementer som har tema, som det kan være smart å tenke på før du reiser hjemmefra.\n\n- Hvitt laken uten stretch\n- Outfit til Ops, jeg kom feil\n- Hippieklær\n- Bevegelige klær som tåler å bli våte\n- Dress/Gallakjole",
   },
   {
     title: "Kontaktinformasjon",
@@ -78,22 +78,22 @@ const generalFaqItems: FaqItem[] = [
         <p>
           Leder av Abakus:
           <br />
-          Henriette Bjørheim, 915 86 737, henriette.bjorheim@abakus.no
+          Kristoffer Krogh Wetterhus, 958 04 396, kristoffer.wetterhus@abakus.no
         </p>
         <p>
           Leder av Arrangementskomiteen til Abakus:
-          <br />
-          Håkon Hoelsæter, 479 55 802, hakon.hoelsaeter@abakus.no
-        </p>
-        <p>
-          Ansvarlig for kommunikasjon med faddere og fadderbarn:
           <br />
           Kaisa Øyre Larsen, 916 41 758, kaisa.larsen@abakus.no
         </p>
         <p>
           Ansvarlig for kommunikasjon med faddere og fadderbarn:
           <br />
-          Ingrid Talseth Singstad, 403 28 322, ingrid.singstad@abakus.no
+          Sven Jansen, 416 02 761, sven.jansen@abakus.no
+        </p>
+        <p>
+          Ansvarlig for kommunikasjon med faddere og fadderbarn:
+          <br />
+          Leo Lie McGrath, 407 81 818, leo.mcgrath@abakus.no
         </p>
       </div>
     ),
@@ -144,7 +144,7 @@ const abakusFaqItems: FaqItem[] = [
     content: (
       <div>
         <p>
-          Abakus består av omtrent 1000 studenter, fra Komtek og Data. Alle
+          Abakus består av omtrent 1000 studenter, fra Cybdat og Data. Alle
           medlemmene i Abakus kalles abakuler.
         </p>
         <p>
@@ -270,7 +270,7 @@ const abakusFaqItems: FaqItem[] = [
           <dt>readme</dt>
           <dd>
             readme er Abakus sitt eget magasin, og har siden 1999 gjort sitt
-            ytterste for å gi studieslitne data- og komtekstudenter et artig
+            ytterste for å gi studieslitne data- og cybdatstudenter et artig
             avbrekk fra pensum. Tre ganger i semesteret kommer det en utgave på
             28 fargesider i akkurat passe mange eksemplarer. Av innhold kan de
             by på artikler om Abakus-arrangement, faglig berikelse av ulik sort
@@ -405,7 +405,7 @@ const abakusFaqItems: FaqItem[] = [
           <dd>
             backup er ansvarlig for å arrangere Masterfadderperioden -
             fadderopplegg for nye studenter på de to-årige masterprogrammene til
-            Komtek og Data. Enkelte dager har vi felles opplegg med
+            Cybdat og Data. Enkelte dager har vi felles opplegg med
             Fadderperioden. Faddere består her av abakuler fra 3., 4. og 5.
             trinn.
           </dd>

--- a/components/Header/HeaderCards.tsx
+++ b/components/Header/HeaderCards.tsx
@@ -30,12 +30,12 @@ const cardData: CardData[] = [
       "Det meste av informasjon til nye studenter kommer via en egen Facebook-gruppe, som det er anbefalt at du blir med i med en gang!",
     buttons: [
       {
-        href: "https://www.facebook.com/groups/280352384450789/",
-        text: "Gruppe for 5-årig master",
+        href: "",
+        text: "Gruppe for 5-årig master (TBD)",
       },
       {
-        href: "https://www.facebook.com/groups/175376555487442/",
-        text: "Gruppe for 2-årig master",
+        href: "",
+        text: "Gruppe for 2-årig master (TBD)",
       },
     ],
   },

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -1,6 +1,7 @@
 import styles from "./styles.module.css";
 import InfoSectionWrapper from "@/components/InfoSectionWrapper";
 import Link from "next/link";
+import { MTDT, MTKOM } from "@/utils/constants";
 
 const Header = () => {
   return (
@@ -8,12 +9,12 @@ const Header = () => {
       <img src="/abakus_logo_black.png" alt="Abakus" className={styles.logo} />
       <h1>Velkommen til Abakus!</h1>
       <p>
-        Vi er linjeforeningen for studentene ved Datateknologi og
-        Kommunikasjonsteknologi og digital sikkerhet på NTNU, og drives av
-        studenter ved disse studiene. Som linjeforening jobber vi for at du som
-        student har det bra under studietiden din. Dette gjør vi blant annet ved
-        å arrangere Fadderperioden, bedriftspresentasjoner, kurs, fester,
-        lavterskel arrangementer og mye mer!
+        Vi er linjeforeningen for studentene ved {MTDT.name} og {MTKOM.name} på
+        NTNU, og drives av studenter ved disse studiene. Som linjeforening
+        jobber vi for at du som student har det bra under studietiden din. Dette
+        gjør vi blant annet ved å arrangere Fadderperioden,
+        bedriftspresentasjoner, kurs, fester, lavterskel arrangementer og mye
+        mer!
       </p>
       <p>
         Denne nettsiden er spesielt rettet mot deg som er ny student, for å

--- a/components/InfoSectionFP/index.tsx
+++ b/components/InfoSectionFP/index.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import styles from "./styles.module.css";
 import InfoSectionWrapper from "@/components/InfoSectionWrapper";
+import { MIDT, MSTCNNS, MTDT, MTKOM } from "@/utils/constants";
 
 const InfoSectionFP = () => {
   return (
@@ -13,24 +14,23 @@ const InfoSectionFP = () => {
         noe, sjekk ut NTNU sin side som hører til ditt studie;
         <br />
         <a href="https://www.ntnu.no/studier/mtkom">
-          5-årig: Kommunikasjonsteknologi og digital sikkerhet (Komtek)
+          5-årig: {MTKOM.name} ({MTKOM.shorthand})
         </a>
         <br />
         <a href="https://www.ntnu.no/studier/mtdt">
-          5-årig: Datateknologi (Data)
+          5-årig: {MTDT.name} ({MTDT.shorthand})
         </a>
         <br />
         <a href="https://www.ntnu.no/studier/mstcnns">
-          2-årig: Digital Infrastructure and Cyber Security (Komtek)
+          2-årig: {MSTCNNS.name} ({MSTCNNS.shorthand})
         </a>{" "}
         <br />
         <a href="https://www.ntnu.no/studier/midt">
-          2-årig: Datateknologi (Data)
+          2-årig: {MIDT.name} ({MIDT.shorthand})
         </a>
       </p>
       <p>
-        Fadderperioden for Datateknologi og Kommunikasjonsteknologi er arrangert
-        av Abakus.
+        Fadderperioden for {MTDT.name} og {MTKOM.name} er arrangert av Abakus.
       </p>
       <p>
         For å bli med må du møte opp på immatrikuleringen, hvor du blir plassert
@@ -44,37 +44,13 @@ const InfoSectionFP = () => {
         (2-årig master) for å få en faddergruppe.
       </p>
       <h3 className={styles.subTitle}>5-årig integrert master</h3>
-      <p>
-        Oppmøte for Datateknologi: Mandag 14. August 12:00 på{" "}
-        <Link href={"https://link.mazemap.com/gqncrU4T"}>Kjel 5</Link>
-      </p>
-      <p>
-        Oppmøte for Kommunikasjonsteknologi: Mandag 14. August 10:00 på{" "}
-        <Link href={"https://link.mazemap.com/Kpd4nMvI"}>EL2</Link>
-      </p>
-      <p>
-        Facebook-gruppe for nye abakuler på 5-årig integrert master{" "}
-        <Link
-          href={"https://www.facebook.com/groups/280352384450789/"}
-          target={"_blank"}
-        >
-          finner du her
-        </Link>
-        .
-      </p>
+      <p>Oppmøte for {MTDT.name}: TBD</p>
+      <p>Oppmøte for {MTKOM.name}: TBD</p>
+      <p>Facebook-gruppe for nye abakuler på 5-årig integrert master: TBD</p>
       <h3 className={styles.subTitle}>2-årig master</h3>
-      <p>Oppmøte for Datateknologi: TBD</p>
-      <p>Oppmøte for Digital Infrastructure and Cyber Security: TBD</p>
-      <p>
-        Facebook-gruppe for nye abakuler på 2-årig master{" "}
-        <Link
-          href={"https://www.facebook.com/groups/175376555487442/"}
-          target={"_blank"}
-        >
-          finner du her
-        </Link>
-        .
-      </p>
+      <p>Oppmøte for {MIDT.name}: TBD</p>
+      <p>Oppmøte for {MSTCNNS.name}: TBD</p>
+      <p>Facebook-gruppe for nye abakuler på 2-årig master: TBD</p>
       <h3 className={styles.subTitle}>Arrangementer</h3>
       <p>
         Du kan se alle arrangementene i Fadderperioden som arrangeres av Abakus

--- a/components/InfoSectionTrondheim/index.tsx
+++ b/components/InfoSectionTrondheim/index.tsx
@@ -1,4 +1,5 @@
 import Card, { CardData, CardWrapper } from "@/components/Card";
+import { MTKOM } from "@/utils/constants";
 import Link from "next/link";
 import InfoSectionWrapper from "../InfoSectionWrapper";
 import styles from "./styles.module.css";
@@ -41,11 +42,11 @@ const cardData: CardData[] = [
     buttons: [
       {
         href: "https://www.ntnu.no/studier/mtdt",
-        text: "Info for Datateknologi",
+        text: "Info for Data",
       },
       {
         href: "https://www.ntnu.no/studier/mtkom",
-        text: "Info for Kommunikasjonsteknologi",
+        text: "Info for Cybdat",
       },
     ],
   },
@@ -70,8 +71,7 @@ const cardData: CardData[] = [
   {
     title: "Komtek-loungen",
     icon: "tv",
-    description:
-      "Kommunikasjonsteknologi sitt eget hvileområde, med kjøkkenkrok, sofa, bordtennisbord og TV",
+    description: `${MTKOM.name} sitt eget hvileområde, med kjøkkenkrok, sofa, bordtennisbord og TV`,
     buttons: [
       { href: "https://link.mazemap.com/IXgO7HUW", text: "Finn med Mazemap" },
     ],

--- a/components/Navbar/index.tsx
+++ b/components/Navbar/index.tsx
@@ -7,7 +7,7 @@ const Navbar = () => {
       <div className={styles.contentWrapper}>
         <div className={styles.navLinksWrapper}>
           <Link href={"/"}>Startside</Link>
-          <Link href={"/events"}>Fadderperioden</Link>
+          <Link href={"/fadderperioden"}>Fadderperioden</Link>
           <Link href={"/masterfadderperioden"}>Masterfadderperioden</Link>
           <Link href={"/faq"}>FAQ</Link>
         </div>

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,13 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  async redirects() {
+    return [{
+      source: '/events',
+      destination: '/fadderperioden',
+      permanent: true,
+    }];
+  },
 };
 
 module.exports = nextConfig;

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,3 +1,4 @@
+import { MTDT, MTKOM } from "@/utils/constants";
 import { Html, Head, Main, NextScript } from "next/document";
 import Script from "next/script";
 
@@ -7,7 +8,7 @@ export default function Document() {
       <Head>
         <meta
           name="description"
-          content="Informasjon til nye studenter på Datateknologi og Kommunikasjonsteknologi på NTNU"
+          content={`Informasjon til nye studenter på ${MTDT.name} og ${MTKOM.name} på NTNU`}
         />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.png" />

--- a/pages/fadderperioden.tsx
+++ b/pages/fadderperioden.tsx
@@ -10,6 +10,7 @@ import FullscreenImage from "@/components/FullscreenImage";
 import { createClient, groq } from "next-sanity";
 import { TypedObject } from "sanity";
 import { FPGroups } from "@/schemas/dayDescription";
+import { MTDT, MTKOM } from "@/utils/constants";
 
 export type DayDescription = {
   date: string;
@@ -55,17 +56,16 @@ export const Events: NextPage<EventsProps> = ({ dayDescriptions }) => {
           noe, sjekk ut NTNU sin side som hører til ditt studie;
           <br />
           <a href="https://www.ntnu.no/studier/mtkom">
-            5-årig: Kommunikasjonsteknologi og digital sikkerhet (Komtek)
+            5-årig: {MTKOM.name} ({MTKOM.shorthand})
           </a>
           <br />
           <a href="https://www.ntnu.no/studier/mtdt">
-            5-årig: Datateknologi (Data)
+            5-årig: {MTDT.name} ({MTDT.shorthand})
           </a>
           <br />
         </p>
         <p>
-          Fadderperioden for Datateknologi og Kommunikasjonsteknologi er
-          arrangert av Abakus.
+          Fadderperioden for {MTDT.name} og {MTKOM.name} er arrangert av Abakus.
         </p>
         <br />
         <p>
@@ -75,24 +75,9 @@ export const Events: NextPage<EventsProps> = ({ dayDescriptions }) => {
           <a href="mailto:fadderperioden@abakus.no">fadderperioden@abakus.no</a>{" "}
           for å få en faddergruppe.
         </p>
-        <p>
-          Oppmøte for Datateknologi: Mandag 14. August 12:00 på{" "}
-          <Link href={"https://link.mazemap.com/gqncrU4T"}>Kjel 5</Link>
-        </p>
-        <p>
-          Oppmøte for Kommunikasjonsteknologi: Mandag 14. August 10:00 på{" "}
-          <Link href={"https://link.mazemap.com/Kpd4nMvI"}>EL2</Link>
-        </p>
-        <p>
-          Facebook-gruppe for nye abakuler på 5-årig integrert master{" "}
-          <Link
-            href={"https://www.facebook.com/groups/280352384450789/"}
-            target={"_blank"}
-          >
-            finner du her
-          </Link>
-          .
-        </p>
+        <p>Oppmøte for {MTDT.name}: TBD</p>
+        <p>Oppmøte for {MTKOM.name}: TBD</p>
+        <p>Facebook-gruppe for nye abakuler på 5-årig integrert master: TBD</p>
       </InfoSectionWrapper>
       {/* <InfoSectionWrapper>
         <FullscreenImage
@@ -104,21 +89,6 @@ export const Events: NextPage<EventsProps> = ({ dayDescriptions }) => {
         />
       </InfoSectionWrapper> */}
       <InfoSectionWrapper>
-        {!isLoading && events.length == 0 && dayDescriptions.length !== 0 && (
-          <p>
-            Klarte ikke hente arrangementer fra abakus.no. Du kan fortsatt finne
-            alle arrangementene på{" "}
-            <Link href={"https://abakus.no"}>abakus.no</Link>.<br />
-            <br />
-          </p>
-        )}
-        {!isLoading && events.length === 0 && dayDescriptions.length === 0 && (
-          <p>
-            Klarte ikke hente arrangementer. Hvis problemet vedvarer, sjekk{" "}
-            <Link href={"https://abakus.no"}>abakus.no</Link> eller
-            facebook-gruppa for nye studenter.
-          </p>
-        )}
         <EventsListView
           isLoadingEvents={isLoading}
           events={events}
@@ -143,8 +113,9 @@ const client = createClient({
 export async function getStaticProps() {
   let dayDescriptions: DayDescription[] = [];
   try {
+    const currentYear = new Date().getFullYear();
     dayDescriptions = await client.fetch(
-      groq`*[_type == "fpDayDescription"] | order(date asc)`
+      groq`*[_type == "fpDayDescription" && date > '${currentYear}-01-01'] | order(date asc)`
     );
   } catch (e) {}
   return {

--- a/pages/masterfadderperioden.tsx
+++ b/pages/masterfadderperioden.tsx
@@ -9,6 +9,7 @@ import Link from "next/link";
 import { createClient, groq } from "next-sanity";
 import { TypedObject } from "sanity";
 import { FPGroups } from "@/schemas/dayDescription";
+import { MIDT, MSTCNNS } from "@/utils/constants";
 
 export type DayDescription = {
   date: string;
@@ -54,16 +55,16 @@ export const Events: NextPage<EventsProps> = ({ dayDescriptions }) => {
           noe, sjekk ut NTNU sin side som hører til ditt studie;
           <br />
           <a href="https://www.ntnu.no/studier/mstcnns">
-            2-årig: Digital Infrastructure and Cyber Security (Komtek)
+            2-årig: {MSTCNNS.name} ({MSTCNNS.shorthand})
           </a>{" "}
           <br />
           <a href="https://www.ntnu.no/studier/midt">
-            2-årig: Datateknologi (Data)
+            2-årig: {MIDT.name} ({MIDT.shorthand})
           </a>
         </p>
         <p>
-          Fadderperioden for Datateknologi og Kommunikasjonsteknologi er
-          arrangert av Abakus.
+          Fadderperioden for {MIDT.name} og {MSTCNNS.name} er arrangert av
+          Abakus.
         </p>
         <br />
         <p>
@@ -75,35 +76,11 @@ export const Events: NextPage<EventsProps> = ({ dayDescriptions }) => {
           </a>{" "}
           for å få en faddergruppe.
         </p>
-        <p>Oppmøte for Datateknologi: TBD</p>
-        <p>Oppmøte for Digital Infrastructure and Cyber Security: TBD</p>
-        <p>
-          Facebook-gruppe for nye abakuler på 2-årig master{" "}
-          <Link
-            href={"https://www.facebook.com/groups/175376555487442/"}
-            target={"_blank"}
-          >
-            finner du her
-          </Link>
-          .
-        </p>
+        <p>Oppmøte for {MIDT.name}: TBD</p>
+        <p>Oppmøte for {MSTCNNS.name}: TBD</p>
+        <p>Facebook-gruppe for nye abakuler på 2-årig master: TBD</p>
       </InfoSectionWrapper>
       <InfoSectionWrapper>
-        {!isLoading && events.length == 0 && dayDescriptions.length !== 0 && (
-          <p>
-            Klarte ikke hente arrangementer fra abakus.no. Du kan fortsatt finne
-            alle arrangementene på{" "}
-            <Link href={"https://abakus.no"}>abakus.no</Link>.<br />
-            <br />
-          </p>
-        )}
-        {!isLoading && events.length === 0 && dayDescriptions.length === 0 && (
-          <p>
-            Klarte ikke hente arrangementer. Hvis problemet vedvarer, sjekk{" "}
-            <Link href={"https://abakus.no"}>abakus.no</Link> eller
-            facebook-gruppa for nye studenter.
-          </p>
-        )}
         <EventsListView
           isLoadingEvents={isLoading}
           events={events}
@@ -128,8 +105,9 @@ const client = createClient({
 export async function getStaticProps() {
   let dayDescriptions: DayDescription[] = [];
   try {
+    const currentYear = new Date().getFullYear();
     dayDescriptions = await client.fetch(
-      groq`*[_type == "mfpDayDescription"] | order(date asc)`
+      groq`*[_type == "mfpDayDescription" && date > '${currentYear}-01-01'] | order(date asc)`
     );
   } catch (e) {}
   return {

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -1,7 +1,9 @@
 import { ApiEvent, ApiResponse, Event } from "./types";
 
-const fromDate = "2023-08-14"; // First day of FP
-const toDate = "2023-09-04"; // One day after Immball
+export const isTBD = true;
+
+const fromDate = "2024-08-12"; // First day of FP
+const toDate = "2024-08-25"; // One day after Immball
 
 // For events in the time period that are not included in FP
 const blackListedEventIds: number[] = [3446, 3420, 3452];
@@ -37,6 +39,7 @@ export const removeBlackListedEvents = (
 export const fetchEvents = async (
   type: keyof typeof specificBlackListedEventIds
 ) => {
+  if (isTBD) return [];
   const res = await fetch(
     `https://lego.abakus.no/api/v1/events?date_after=${fromDate}&date_before=${toDate}`
   );

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -1,0 +1,12 @@
+type Degree = { name: string; shorthand: string };
+
+export const MTDT: Degree = { name: "Dateteknologi", shorthand: "Data" };
+export const MTKOM: Degree = {
+  name: "Cybersikkerhet og datakommunikasjon",
+  shorthand: "Cybdat",
+};
+export const MIDT: Degree = MTDT;
+export const MSTCNNS: Degree = {
+  name: "Digital Infrastructure and Cyber Security",
+  shorthand: "Cybdat",
+};


### PR DESCRIPTION
As the summer is approaching it's time to reset the information on the site until the plan is set and the new facebook-groups are created(:

We're calling komtek cybdat now right? 👀 

Resolves ABA-931