### PR TITLE
Add icon to external links

### DIFF
--- a/components/Button/index.tsx
+++ b/components/Button/index.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import Link from "@/components/Link";
 import styles from "./styles.module.css";
 
 export type CardData = {

--- a/components/Card/index.tsx
+++ b/components/Card/index.tsx
@@ -1,5 +1,5 @@
 import Icon from "@/components/Icon";
-import Link from "next/link";
+import Link from "@/components/Link";
 import { PropsWithChildren } from "react";
 import Button from "../Button";
 import styles from "./styles.module.css";

--- a/components/EventsListView/index.tsx
+++ b/components/EventsListView/index.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/utils/date";
 import { Event } from "@/utils/types";
 import { PortableText, PortableTextComponents } from "@portabletext/react";
-import Link from "next/link";
+import Link from "@/components/Link";
 import { useMemo } from "react";
 import CollapsibleItem from "./CollapsibleItem";
 import EventItem from "./EventItem";
@@ -34,13 +34,13 @@ const components: PortableTextComponents = {
         ? "_blank"
         : undefined;
       return (
-        <a
+        <Link
           href={value?.href}
           target={target}
           rel={target === "_blank" ? "noindex nofollow" : undefined}
         >
           {children}
-        </a>
+        </Link>
       );
     },
   },
@@ -150,7 +150,7 @@ const EventsListView: React.FC<EventsListViewProps> = ({
       ))}
       <p>
         Se alle Abakus sine arrangementer på{" "}
-        <a href="https://abakus.no/events">abakus.no/events</a>
+        <Link href="https://abakus.no/events">abakus.no/events</Link>
       </p>
     </div>
   );

--- a/components/FaqContent/index.tsx
+++ b/components/FaqContent/index.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import Link from "@/components/Link";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import InfoSectionWrapper from "../InfoSectionWrapper";
@@ -33,8 +33,8 @@ const FaqContent: React.FC = () => {
       {renderFaqItems(generalFaqItems)}
       <p>
         Lurer du på noe mer? Send en mail til Webkom på{" "}
-        <a href="mailto:webkom@abakus.no">webkom@abakus.no</a>, så hjelper vi
-        deg finne svaret - og legger det ut her så andre også kan finne det.
+        <Link href="mailto:webkom@abakus.no">webkom@abakus.no</Link>, så hjelper
+        vi deg finne svaret - og legger det ut her så andre også kan finne det.
       </p>
     </InfoSectionWrapper>
   );
@@ -114,8 +114,8 @@ const generalFaqItems: FaqItem[] = [
         </p>
         <p>
           Om du går inn på{" "}
-          <a href="https://abakus.no/events">abakus.no/events</a> på PC og blar
-          helt nederst på siden, får du alternativene mellom tre mulige
+          <Link href="https://abakus.no/events">abakus.no/events</Link> på PC og
+          blar helt nederst på siden, får du alternativene mellom tre mulige
           kalendere. Enten alle arrangementer, alle registreringstidspunkter
           (påmeldingstidspunkt) eller dine møter og favorittarrangementer.
         </p>

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -1,6 +1,6 @@
 import styles from "./styles.module.css";
 import InfoSectionWrapper from "@/components/InfoSectionWrapper";
-import Link from "next/link";
+import Link from "@/components/Link";
 import { MTDT, MTKOM } from "@/utils/constants";
 
 const Header = () => {

--- a/components/InfoSectionFP/index.tsx
+++ b/components/InfoSectionFP/index.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import Link from "@/components/Link";
 import styles from "./styles.module.css";
 import InfoSectionWrapper from "@/components/InfoSectionWrapper";
 import {
@@ -20,21 +20,21 @@ const InfoSectionFP = () => {
         instituttet/fakultetet. For å være sikker på at du ikke går glipp av
         noe, sjekk ut NTNU sin side som hører til ditt studie;
         <br />
-        <a href="https://www.ntnu.no/studier/mtkom">
+        <Link href="https://www.ntnu.no/studier/mtkom">
           5-årig: {MTKOM.name} ({MTKOM.shorthand})
-        </a>
+        </Link>
         <br />
-        <a href="https://www.ntnu.no/studier/mtdt">
+        <Link href="https://www.ntnu.no/studier/mtdt">
           5-årig: {MTDT.name} ({MTDT.shorthand})
-        </a>
+        </Link>
         <br />
-        <a href="https://www.ntnu.no/studier/mstcnns">
+        <Link href="https://www.ntnu.no/studier/mstcnns">
           2-årig: {MSTCNNS.name} ({MSTCNNS.shorthand})
-        </a>{" "}
+        </Link>{" "}
         <br />
-        <a href="https://www.ntnu.no/studier/midt">
+        <Link href="https://www.ntnu.no/studier/midt">
           2-årig: {MIDT.name} ({MIDT.shorthand})
-        </a>
+        </Link>
       </p>
       <p>
         Fadderperioden for {MTDT.name} og {MTKOM.name} er arrangert av Abakus.
@@ -43,11 +43,13 @@ const InfoSectionFP = () => {
         For å bli med må du møte opp på immatrikuleringen, hvor du blir plassert
         i en faddergruppe og får mer informasjon. Hvis du ikke får møtt opp,
         send en epost til{" "}
-        <a href="mailto:fadderperioden@abakus.no">fadderperioden@abakus.no</a>{" "}
+        <Link href="mailto:fadderperioden@abakus.no">
+          fadderperioden@abakus.no
+        </Link>{" "}
         (5-årig integrert master) eller{" "}
-        <a href="mailto:masterfadderperioden@abakus.no">
+        <Link href="mailto:masterfadderperioden@abakus.no">
           masterfadderperioden@abakus.no
-        </a>{" "}
+        </Link>{" "}
         (2-årig master) for å få en faddergruppe.
       </p>
       <h3 className={styles.subTitle}>5-årig integrert master</h3>
@@ -58,7 +60,7 @@ const InfoSectionFP = () => {
         {FACEBOOK_GROUP_FIRSTYEARS === "" ? (
           "TBD"
         ) : (
-          <a href={FACEBOOK_GROUP_FIRSTYEARS}>facebook.com/groups/...</a>
+          <Link href={FACEBOOK_GROUP_FIRSTYEARS}>facebook.com/groups/...</Link>
         )}
       </p>
       <h3 className={styles.subTitle}>2-årig master</h3>
@@ -69,7 +71,7 @@ const InfoSectionFP = () => {
         {FACEBOOK_GROUP_FOURTHYEARS === "" ? (
           "TBD"
         ) : (
-          <a href={FACEBOOK_GROUP_FOURTHYEARS}>facebook.com/groups/...</a>
+          <Link href={FACEBOOK_GROUP_FOURTHYEARS}>facebook.com/groups/...</Link>
         )}
       </p>
       <h3 className={styles.subTitle}>Arrangementer</h3>

--- a/components/InfoSectionStudentPub/index.tsx
+++ b/components/InfoSectionStudentPub/index.tsx
@@ -1,7 +1,7 @@
 import styles from "./styles.module.css";
 import InfoSectionWrapper from "@/components/InfoSectionWrapper";
 import Image from "next/image";
-import Link from "next/link";
+import Link from "@/components/Link";
 
 const InfoSectionStudentPub = () => {
   return (

--- a/components/InfoSectionStudy/index.tsx
+++ b/components/InfoSectionStudy/index.tsx
@@ -1,7 +1,7 @@
 import styles from "./styles.module.css";
 import InfoSectionWrapper from "@/components/InfoSectionWrapper";
 import Card, { CardData, CardWrapper } from "@/components/Card";
-import Link from "next/link";
+import Link from "@/components/Link";
 
 const InfoSectionStudy = () => {
   return (

--- a/components/InfoSectionTrondheim/index.tsx
+++ b/components/InfoSectionTrondheim/index.tsx
@@ -1,6 +1,6 @@
 import Card, { CardData, CardWrapper } from "@/components/Card";
 import { MTKOM } from "@/utils/constants";
-import Link from "next/link";
+import Link from "@/components/Link";
 import InfoSectionWrapper from "../InfoSectionWrapper";
 import styles from "./styles.module.css";
 

--- a/components/InnbyttereContent/index.tsx
+++ b/components/InnbyttereContent/index.tsx
@@ -3,6 +3,7 @@ import styles from "./styles.module.css";
 import { MTDT, MTKOM } from "@/utils/constants";
 import Card from "@/components/Card";
 import Icon from "@/components/Icon";
+import Link from "@/components/Link";
 
 const InnbyttereContent: React.FC = () => {
   return (
@@ -16,9 +17,9 @@ const InnbyttereContent: React.FC = () => {
         <p>
           Her finner du informasjon som kan være nyttig for deg som innbytter.
           Hvis du lurer på noe mer, er det bare å ta kontakt med{" "}
-          <a href="mailto:prosjekt-innbyttere@abakus.no">
+          <Link href="mailto:prosjekt-innbyttere@abakus.no">
             prosjekt-innbyttere@abakus.no
-          </a>
+          </Link>
           .
         </p>
       </InfoSectionWrapper>

--- a/components/Link/index.tsx
+++ b/components/Link/index.tsx
@@ -4,8 +4,6 @@ import styles from "./styles.module.css";
 
 interface LinkProps extends React.ComponentProps<typeof NextLink> {
   children: React.ReactNode;
-  internal?: boolean;
-  external?: boolean;
 }
 
 const internalRegEx = /^(#.*|\/.*|(.*(abakus\.no|localhost:\d)(\/.*)?))$/;
@@ -22,21 +20,18 @@ const internalRegEx = /^(#.*|\/.*|(.*(abakus\.no|localhost:\d)(\/.*)?))$/;
  * - <string>localhost:<digit>
  * - <string>localhost:<digit>/<string>
  *
- * @param external - overrides the above mentioned check (takes precedence over `internal`)
- * @param internal - overrides the above mentioned check
  * @returns a next link with or without icon appended
  */
-export function Link({ children, external, internal, ...props }: LinkProps) {
-  const isExternal =
-    external ?? internal ?? !internalRegEx.test(props.href.toString());
+const Link = ({ children, ...props }: LinkProps) => {
+  const isExternal = !internalRegEx.test(props.href.toString());
   return (
-    <NextLink {...props}>
+    <NextLink target={isExternal ? "_blank" : "_self"} {...props}>
       <span className={styles.children}>
         {children}
         {isExternal && <Icon className={styles.icon} name="open-outline" />}
       </span>
     </NextLink>
   );
-}
+};
 
 export default Link;

--- a/components/Link/index.tsx
+++ b/components/Link/index.tsx
@@ -1,0 +1,42 @@
+import NextLink from "next/link";
+import Icon from "../Icon";
+import styles from "./styles.module.css";
+
+interface LinkProps extends React.ComponentProps<typeof NextLink> {
+  children: React.ReactNode;
+  internal?: boolean;
+  external?: boolean;
+}
+
+const internalRegEx = /^(#.*|\/.*|(.*(abakus\.no|localhost:\d)(\/.*)?))$/;
+
+/**
+ * {@link https://nextjs.org/docs/api-reference/next/link | next/link} wrapper adding icon to external links.
+ *
+ * A link is external if href does not match any of the following
+ * `<string>` is any arbitrary string (including the empty string)
+ * - #<string>
+ * - /<string>
+ * - <string>abakus.no
+ * - <string>abakus.no/<string>
+ * - <string>localhost:<digit>
+ * - <string>localhost:<digit>/<string>
+ *
+ * @param external - overrides the above mentioned check (takes precedence over `internal`)
+ * @param internal - overrides the above mentioned check
+ * @returns a next link with or without icon appended
+ */
+export function Link({ children, external, internal, ...props }: LinkProps) {
+  const isExternal =
+    external ?? internal ?? !internalRegEx.test(props.href.toString());
+  return (
+    <NextLink {...props}>
+      <span className={styles.children}>
+        {children}
+        {isExternal && <Icon className={styles.icon} name="open-outline" />}
+      </span>
+    </NextLink>
+  );
+}
+
+export default Link;

--- a/components/Link/styles.module.css
+++ b/components/Link/styles.module.css
@@ -1,0 +1,9 @@
+.icon {
+  display: inline-flex;
+}
+
+.children {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+}

--- a/components/Navbar/index.tsx
+++ b/components/Navbar/index.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import Link from "@/components/Link";
 import styles from "./styles.module.css";
 import Icon from "../Icon";
 import { useEffect, useState } from "react";

--- a/components/QuickLinks/index.tsx
+++ b/components/QuickLinks/index.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import Link from "@/components/Link";
 import styles from "./styles.module.css";
 import { useEffect, useRef, useState } from "react";
 

--- a/pages/fadderperioden.tsx
+++ b/pages/fadderperioden.tsx
@@ -5,7 +5,7 @@ import EventsListView from "@/components/EventsListView";
 import { deserializeEvents, fetchEvents } from "@/utils/api";
 import { NextPage } from "next";
 import { ApiEvent } from "@/utils/types";
-import Link from "next/link";
+import Link from "@/components/Link";
 import FullscreenImage from "@/components/FullscreenImage";
 import { groq } from "next-sanity";
 import { TypedObject } from "sanity";
@@ -56,13 +56,13 @@ export const Events: NextPage<EventsProps> = ({ dayDescriptions }) => {
           instituttet/fakultetet. For å være sikker på at du ikke går glipp av
           noe, sjekk ut NTNU sin side som hører til ditt studie;
           <br />
-          <a href="https://www.ntnu.no/studier/mtkom">
+          <Link href="https://www.ntnu.no/studier/mtkom">
             5-årig: {MTKOM.name} ({MTKOM.shorthand})
-          </a>
+          </Link>
           <br />
-          <a href="https://www.ntnu.no/studier/mtdt">
+          <Link href="https://www.ntnu.no/studier/mtdt">
             5-årig: {MTDT.name} ({MTDT.shorthand})
-          </a>
+          </Link>
           <br />
         </p>
         <p>
@@ -73,7 +73,9 @@ export const Events: NextPage<EventsProps> = ({ dayDescriptions }) => {
           For å bli med må du møte opp på immatrikuleringen, hvor du blir
           plassert i en faddergruppe og får mer informasjon. Hvis du ikke får
           møtt opp, send en epost til{" "}
-          <a href="mailto:fadderperioden@abakus.no">fadderperioden@abakus.no</a>{" "}
+          <Link href="mailto:fadderperioden@abakus.no">
+            fadderperioden@abakus.no
+          </Link>{" "}
           for å få en faddergruppe.
         </p>
         <p>Oppmøte for {MTDT.name}: TBD</p>
@@ -83,7 +85,9 @@ export const Events: NextPage<EventsProps> = ({ dayDescriptions }) => {
           {FACEBOOK_GROUP_FIRSTYEARS === "" ? (
             "TBD"
           ) : (
-            <a href={FACEBOOK_GROUP_FIRSTYEARS}>facebook.com/groups/...</a>
+            <Link href={FACEBOOK_GROUP_FIRSTYEARS}>
+              facebook.com/groups/...
+            </Link>
           )}
         </p>
       </InfoSectionWrapper>

--- a/pages/masterfadderperioden.tsx
+++ b/pages/masterfadderperioden.tsx
@@ -5,7 +5,7 @@ import EventsListView from "@/components/EventsListView";
 import { deserializeEvents, fetchEvents } from "@/utils/api";
 import { NextPage } from "next";
 import { ApiEvent } from "@/utils/types";
-import Link from "next/link";
+import Link from "@/components/Link";
 import { groq } from "next-sanity";
 import { TypedObject } from "sanity";
 import { FPGroups } from "@/schemas/dayDescription";
@@ -55,13 +55,13 @@ export const Events: NextPage<EventsProps> = ({ dayDescriptions }) => {
           instituttet/fakultetet. For å være sikker på at du ikke går glipp av
           noe, sjekk ut NTNU sin side som hører til ditt studie;
           <br />
-          <a href="https://www.ntnu.no/studier/mstcnns">
+          <Link href="https://www.ntnu.no/studier/mstcnns">
             2-årig: {MSTCNNS.name} ({MSTCNNS.shorthand})
-          </a>{" "}
+          </Link>{" "}
           <br />
-          <a href="https://www.ntnu.no/studier/midt">
+          <Link href="https://www.ntnu.no/studier/midt">
             2-årig: {MIDT.name} ({MIDT.shorthand})
-          </a>
+          </Link>
         </p>
         <p>
           Fadderperioden for {MIDT.name} og {MSTCNNS.name} er arrangert av
@@ -72,9 +72,9 @@ export const Events: NextPage<EventsProps> = ({ dayDescriptions }) => {
           For å bli med må du møte opp på immatrikuleringen, hvor du blir
           plassert i en faddergruppe og får mer informasjon. Hvis du ikke får
           møtt opp, send en epost til{" "}
-          <a href="mailto:masterfadderperioden@abakus.no">
+          <Link href="mailto:masterfadderperioden@abakus.no">
             masterfadderperioden@abakus.no
-          </a>{" "}
+          </Link>{" "}
           for å få en faddergruppe.
         </p>
         <p>Oppmøte for {MIDT.name}: 12.15 i H1, Hovedbygget</p>
@@ -84,7 +84,9 @@ export const Events: NextPage<EventsProps> = ({ dayDescriptions }) => {
           {FACEBOOK_GROUP_FOURTHYEARS === "" ? (
             "TBD"
           ) : (
-            <a href={FACEBOOK_GROUP_FOURTHYEARS}>facebook.com/groups/...</a>
+            <Link href={FACEBOOK_GROUP_FOURTHYEARS}>
+              facebook.com/groups/...
+            </Link>
           )}
         </p>
       </InfoSectionWrapper>

--- a/pages/om-abakus.tsx
+++ b/pages/om-abakus.tsx
@@ -1,6 +1,6 @@
 import styles from "@/styles/Home.module.css";
 import InfoSectionWrapper from "@/components/InfoSectionWrapper";
-import Link from "next/link";
+import Link from "@/components/Link";
 import AboutCard from "../components/AboutCard";
 
 const committees = [
@@ -130,9 +130,9 @@ const OmAbakus = () => {
           <li>Øvrig styremedlem: Oskar Larsen</li>
         </ul>
         <p>
-          <a href="https://abakus.no/pages/styrer/12">
+          <Link href="https://abakus.no/pages/styrer/12">
             Les mer om Hovedstyret på abakus.no (krever innlogging)
-          </a>
+          </Link>
         </p>
       </AboutCard>
       <br />
@@ -186,9 +186,9 @@ const OmAbakus = () => {
       </p>
 
       <p>
-        <a href="https://abakus.no/pages/komiteer/4">
+        <Link href="https://abakus.no/pages/komiteer/4">
           Les mer om komitéene på abakus.no (krever innlogging)
-        </a>
+        </Link>
       </p>
 
       {committees.map((committee) => (
@@ -222,9 +222,9 @@ const OmAbakus = () => {
           Immatrikuleringsballet.
         </p>
         <p>
-          <a href="https://abakus.no/pages/grupper/104-revyen">
+          <Link href="https://abakus.no/pages/grupper/104-revyen">
             Les mer om revyen på abakus.no
-          </a>
+          </Link>
         </p>
       </AboutCard>
 
@@ -240,9 +240,9 @@ const OmAbakus = () => {
           med andre ord mye å finne på gjennom undergrupper.
         </p>
         <p>
-          <a href="https://abakus.no/pages/grupper/31-undergrupper">
+          <Link href="https://abakus.no/pages/grupper/31-undergrupper">
             Les mer om undergrupper på abakus.no
-          </a>
+          </Link>
         </p>
       </AboutCard>
 
@@ -259,9 +259,9 @@ const OmAbakus = () => {
           arrangerer turer i skog og fjell, og AbaCraft som miner og crafter.
         </p>
         <p>
-          <a href="https://abakus.no/interest-groups">
+          <Link href="https://abakus.no/interest-groups">
             Finn alle interessegruppene på abakus.no (krever innlogging)
-          </a>
+          </Link>
           <br />
           NB: Interessegruppene pleier å kommunisere via Facebook - dette står
           det informasjon om inne på siden til den enkelte interessegruppen. Om
@@ -269,9 +269,9 @@ const OmAbakus = () => {
           interessegruppe&quot; i navnet for å være lettere å søke etter.
         </p>
         <p>
-          <a href="https://abakus.no/pages/grupper/39-praktisk-informasjon">
+          <Link href="https://abakus.no/pages/grupper/39-praktisk-informasjon">
             Les mer om interessegrupper på abakus.no
-          </a>
+          </Link>
         </p>
       </AboutCard>
     </InfoSectionWrapper>


### PR DESCRIPTION
Create a `Link` component which is just a wrapper for `next/link` but appends a icon to the children string if the link is to an external page.

A link is external if href does not match any of the following
`<string>` is any arbitrary string (including the empty string)
- `#<string>`
- `/<string>`
- `<string>abakus.no`
- `<string>abakus.no/<string>`
- `<string>localhost:<digit>`
 - `<string>localhost:<digit>/<string>`

This could be changed to only match links only matching the full domain and not include other `abakus.no` domains.

![Screenshot 2025-05-15 at 14 56 38](https://github.com/user-attachments/assets/9c67dc0b-7411-44a1-8777-e167d7e40430)

Resolves ABA-536