### PR TITLE
Get props server side instead of on build (static)

### DIFF
--- a/pages/fadderperioden.tsx
+++ b/pages/fadderperioden.tsx
@@ -117,7 +117,7 @@ export const Events: NextPage<EventsProps> = ({
   );
 };
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   let dayDescriptions: DayDescription[] = [];
   try {
     const currentYear = new Date().getFullYear();

--- a/pages/fadderperioden.tsx
+++ b/pages/fadderperioden.tsx
@@ -11,7 +11,7 @@ import { groq } from "next-sanity";
 import { TypedObject } from "sanity";
 import { FPGroups } from "@/schemas/dayDescription";
 import { FACEBOOK_GROUP_FIRSTYEARS, MTDT, MTKOM } from "@/utils/constants";
-import { sanityClient, sanityFetch } from "@/utils/sanity";
+import { sanityFetch } from "@/utils/sanity";
 import getSettings, { BlacklistType, Settings } from "@/utils/settings";
 
 export type DayDescription = {

--- a/pages/fadderperioden.tsx
+++ b/pages/fadderperioden.tsx
@@ -11,7 +11,7 @@ import { groq } from "next-sanity";
 import { TypedObject } from "sanity";
 import { FPGroups } from "@/schemas/dayDescription";
 import { FACEBOOK_GROUP_FIRSTYEARS, MTDT, MTKOM } from "@/utils/constants";
-import { sanityFetch } from "@/utils/sanity";
+import { sanityClient } from "@/utils/sanity";
 import getSettings, { BlacklistType, Settings } from "@/utils/settings";
 
 export type DayDescription = {
@@ -121,9 +121,9 @@ export async function getStaticProps() {
   let dayDescriptions: DayDescription[] = [];
   try {
     const currentYear = new Date().getFullYear();
-    dayDescriptions = await sanityFetch({
-      query: groq`*[_type == "fpDayDescription" && date > '${currentYear}-01-01'] | order(date asc)`
-    });
+    dayDescriptions = await sanityClient.fetch(
+      groq`*[_type == "fpDayDescription" && date > '${currentYear}-01-01'] | order(date asc)`
+    );
   } catch (e) {}
   const settings = await getSettings();
   return {
@@ -131,6 +131,7 @@ export async function getStaticProps() {
       dayDescriptions,
       settings,
     },
+    revalidate: 60,
   };
 }
 

--- a/pages/fadderperioden.tsx
+++ b/pages/fadderperioden.tsx
@@ -11,7 +11,7 @@ import { groq } from "next-sanity";
 import { TypedObject } from "sanity";
 import { FPGroups } from "@/schemas/dayDescription";
 import { FACEBOOK_GROUP_FIRSTYEARS, MTDT, MTKOM } from "@/utils/constants";
-import { sanityClient } from "@/utils/sanity";
+import { sanityClient, sanityFetch } from "@/utils/sanity";
 import getSettings, { BlacklistType, Settings } from "@/utils/settings";
 
 export type DayDescription = {
@@ -117,13 +117,13 @@ export const Events: NextPage<EventsProps> = ({
   );
 };
 
-export async function getServerSideProps() {
+export async function getStaticProps() {
   let dayDescriptions: DayDescription[] = [];
   try {
     const currentYear = new Date().getFullYear();
-    dayDescriptions = await sanityClient.fetch(
-      groq`*[_type == "fpDayDescription" && date > '${currentYear}-01-01'] | order(date asc)`
-    );
+    dayDescriptions = await sanityFetch({
+      query: groq`*[_type == "fpDayDescription" && date > '${currentYear}-01-01'] | order(date asc)`
+    });
   } catch (e) {}
   const settings = await getSettings();
   return {

--- a/pages/masterfadderperioden.tsx
+++ b/pages/masterfadderperioden.tsx
@@ -10,7 +10,7 @@ import { groq } from "next-sanity";
 import { TypedObject } from "sanity";
 import { FPGroups } from "@/schemas/dayDescription";
 import { FACEBOOK_GROUP_FOURTHYEARS, MIDT, MSTCNNS } from "@/utils/constants";
-import { sanityClient } from "@/utils/sanity";
+import { sanityClient, sanityFetch } from "@/utils/sanity";
 import getSettings, { BlacklistType, Settings } from "@/utils/settings";
 
 export type DayDescription = {
@@ -107,15 +107,15 @@ export const Events: NextPage<EventsProps> = ({
   );
 };
 
-export async function getServerSideProps() {
+export async function getStaticProps() {
   let dayDescriptions: DayDescription[] = [];
   try {
     const currentYear = new Date().getFullYear();
-    dayDescriptions = await sanityClient.fetch(
-      groq`*[_type == "mfpDayDescription" && date > '${currentYear}-01-01'] | order(date asc)`
-    );
+    dayDescriptions = await sanityFetch({
+      query: groq`*[_type == "mfpDayDescription" && date > '${currentYear}-01-01'] | order(date asc)`,
+    });
   } catch (e) {}
-  
+
   const settings = await getSettings();
   return {
     props: {

--- a/pages/masterfadderperioden.tsx
+++ b/pages/masterfadderperioden.tsx
@@ -10,7 +10,7 @@ import { groq } from "next-sanity";
 import { TypedObject } from "sanity";
 import { FPGroups } from "@/schemas/dayDescription";
 import { FACEBOOK_GROUP_FOURTHYEARS, MIDT, MSTCNNS } from "@/utils/constants";
-import { sanityFetch } from "@/utils/sanity";
+import { sanityClient } from "@/utils/sanity";
 import getSettings, { BlacklistType, Settings } from "@/utils/settings";
 
 export type DayDescription = {
@@ -111,17 +111,18 @@ export async function getStaticProps() {
   let dayDescriptions: DayDescription[] = [];
   try {
     const currentYear = new Date().getFullYear();
-    dayDescriptions = await sanityFetch({
-      query: groq`*[_type == "mfpDayDescription" && date > '${currentYear}-01-01'] | order(date asc)`,
-    });
+    dayDescriptions = await sanityClient.fetch(
+      groq`*[_type == "mfpDayDescription" && date > '${currentYear}-01-01'] | order(date asc)`
+    );
   } catch (e) {}
-
+  
   const settings = await getSettings();
   return {
     props: {
       dayDescriptions,
       settings,
     },
+    revalidate: 60,
   };
 }
 

--- a/pages/masterfadderperioden.tsx
+++ b/pages/masterfadderperioden.tsx
@@ -107,7 +107,7 @@ export const Events: NextPage<EventsProps> = ({
   );
 };
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   let dayDescriptions: DayDescription[] = [];
   try {
     const currentYear = new Date().getFullYear();

--- a/pages/masterfadderperioden.tsx
+++ b/pages/masterfadderperioden.tsx
@@ -10,7 +10,7 @@ import { groq } from "next-sanity";
 import { TypedObject } from "sanity";
 import { FPGroups } from "@/schemas/dayDescription";
 import { FACEBOOK_GROUP_FOURTHYEARS, MIDT, MSTCNNS } from "@/utils/constants";
-import { sanityClient, sanityFetch } from "@/utils/sanity";
+import { sanityFetch } from "@/utils/sanity";
 import getSettings, { BlacklistType, Settings } from "@/utils/settings";
 
 export type DayDescription = {

--- a/utils/sanity.ts
+++ b/utils/sanity.ts
@@ -1,4 +1,4 @@
-import { createClient, type QueryParams, type ClientConfig } from "next-sanity";
+import { createClient } from "next-sanity";
 
 export const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!;
 export const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET!;
@@ -12,33 +12,3 @@ export const sanityClient = createClient({
   apiVersion, // https://www.sanity.io/docs/api-versioning
   useCdn: true, // https://www.sanity.io/docs/apis-and-sdks/asset-cdn
 });
-
-/**
-* A wrapper function for sanityClient.fetch() to cache the results in the nextjs cache
-*
-* Default revalidation time is 60 seconds, meaning it will only query sanity max once per minute.
-*
-* @param query - query string to pass to sanityClient.fetch()
-* @param params - params passed to sanityClient.fetch()
-* @param revalidate - default 60 (seconds)
-* @param config - New client configuration properties, shallowly merged with existing configuration.
-* Example: { useCdn: false } to use Sanity API instead of CDN. Useful for static generation.
-* @returns a promise containing the result from sanityClient.fetch()
-*/
-export async function sanityFetch<const QueryString extends string>({
-  query,
-  params = {},
-  revalidate = 60, // default revalidation time in seconds
-  config,
-}: {
-  query: QueryString
-  params?: QueryParams
-  revalidate?: number | false
-  config?: ClientConfig
-}) {
-  return sanityClient.withConfig(config).fetch(query, params, {
-    next: {
-      revalidate: revalidate,
-    },
-  })
-}

--- a/utils/sanity.ts
+++ b/utils/sanity.ts
@@ -1,4 +1,4 @@
-import { createClient } from "next-sanity";
+import { createClient, type QueryParams, type ClientConfig } from "next-sanity";
 
 export const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!;
 export const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET!;
@@ -10,5 +10,35 @@ export const sanityClient = createClient({
   dataset,
   token,
   apiVersion, // https://www.sanity.io/docs/api-versioning
-  useCdn: false,
+  useCdn: true, // https://www.sanity.io/docs/apis-and-sdks/asset-cdn
 });
+
+/**
+* A wrapper function for sanityClient.fetch() to cache the results in the nextjs cache
+*
+* Default revalidation time is 60 seconds, meaning it will only query sanity max once per minute.
+*
+* @param query - query string to pass to sanityClient.fetch()
+* @param params - params passed to sanityClient.fetch()
+* @param revalidate - default 60 (seconds)
+* @param config - New client configuration properties, shallowly merged with existing configuration.
+* Example: { useCdn: false } to use Sanity API instead of CDN. Useful for static generation.
+* @returns a promise containing the result from sanityClient.fetch()
+*/
+export async function sanityFetch<const QueryString extends string>({
+  query,
+  params = {},
+  revalidate = 60, // default revalidation time in seconds
+  config,
+}: {
+  query: QueryString
+  params?: QueryParams
+  revalidate?: number | false
+  config?: ClientConfig
+}) {
+  return sanityClient.withConfig(config).fetch(query, params, {
+    next: {
+      revalidate: revalidate,
+    },
+  })
+}

--- a/utils/settings.ts
+++ b/utils/settings.ts
@@ -1,5 +1,5 @@
 import { groq } from "next-sanity";
-import { sanityClient, sanityFetch } from "./sanity";
+import { sanityFetch } from "./sanity";
 import { SiteSettings } from "@/sanity.types";
 
 export enum BlacklistType {

--- a/utils/settings.ts
+++ b/utils/settings.ts
@@ -1,5 +1,5 @@
 import { groq } from "next-sanity";
-import { sanityFetch } from "./sanity";
+import { sanityClient } from "./sanity";
 import { SiteSettings } from "@/sanity.types";
 
 export enum BlacklistType {
@@ -32,11 +32,11 @@ export type Settings = SiteSettings & {
 export async function getSettings(): Promise<Settings> {
   let data: SiteSettings | undefined;
   try {
-    data = await sanityFetch({
-      query: groq`*[_type == "siteSettings"]`,
-    }).then((res: SiteSettings[]) =>
-      res.find((item) => item._id === "siteSettings")
-    );
+    data = await sanityClient
+      .fetch(groq`*[_type == "siteSettings"]`)
+      .then((res: SiteSettings[]) =>
+        res.find((item) => item._id === "siteSettings")
+      );
   } catch (e) {}
 
   if (!data) return null;

--- a/utils/settings.ts
+++ b/utils/settings.ts
@@ -64,7 +64,7 @@ export async function getSettings(): Promise<Settings> {
 
 /**
  * Inject settings into a props object
- * Intended to be used in eg. `getStaticProps()` to also be able to access siteSettings
+ * Intended to be used in eg. `getServerSideProps()` to also be able to access siteSettings
  *
  * @example
  * // returns { props: { myProp, settings } }

--- a/utils/settings.ts
+++ b/utils/settings.ts
@@ -1,5 +1,5 @@
 import { groq } from "next-sanity";
-import { sanityClient } from "./sanity";
+import { sanityClient, sanityFetch } from "./sanity";
 import { SiteSettings } from "@/sanity.types";
 
 export enum BlacklistType {
@@ -32,11 +32,11 @@ export type Settings = SiteSettings & {
 export async function getSettings(): Promise<Settings> {
   let data: SiteSettings | undefined;
   try {
-    data = await sanityClient
-      .fetch(groq`*[_type == "siteSettings"]`)
-      .then((res: SiteSettings[]) =>
-        res.find((item) => item._id === "siteSettings")
-      );
+    data = await sanityFetch({
+      query: groq`*[_type == "siteSettings"]`,
+    }).then((res: SiteSettings[]) =>
+      res.find((item) => item._id === "siteSettings")
+    );
   } catch (e) {}
 
   if (!data) return null;
@@ -64,7 +64,7 @@ export async function getSettings(): Promise<Settings> {
 
 /**
  * Inject settings into a props object
- * Intended to be used in eg. `getServerSideProps()` to also be able to access siteSettings
+ * Intended to be used in eg. `getStaticProps()` to also be able to access siteSettings
  *
  * @example
  * // returns { props: { myProp, settings } }


### PR DESCRIPTION
Currently we use `getStaticProps()` which only get the props on build. This defeats the purpose of using sanity as changes requires the app to be rebuilt to take effect. 