### PR TITLE
Move faq to sanity

### DIFF
--- a/components/FaqContent/index.tsx
+++ b/components/FaqContent/index.tsx
@@ -13,12 +13,9 @@ const FaqContent: React.FC<{ faq?: FetchFaqResult }> = ({ faq }) => {
   useEffect(() => setHash(asPath.split("#")[1]), [asPath]);
 
   const renderFaqItems = () =>
-    faq?.map(({ question, answer }) => {
-      const key = encodeURIComponent(
-        question.replace(/\s+/g, "-").toLowerCase()
-      );
+    faq?.map(({ question, answer, slug }) => {
+      const key = slug.current;
       const togglePath = () => replace(hash !== key ? "#" + key : "");
-
       return (
         <div className={styles.faqItem} key={key} id={key}>
           <details open={hash === key}>

--- a/components/FaqContent/index.tsx
+++ b/components/FaqContent/index.tsx
@@ -3,34 +3,38 @@ import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import InfoSectionWrapper from "../InfoSectionWrapper";
 import styles from "./styles.module.css";
+import { FetchFaqResult } from "@/studio/generated/sanity.types";
+import { PortableText } from "next-sanity";
 
-const FaqContent: React.FC = () => {
+const FaqContent: React.FC<{ faq?: FetchFaqResult }> = ({ faq }) => {
   const { asPath, replace } = useRouter();
   const [hash, setHash] = useState<string>();
 
   useEffect(() => setHash(asPath.split("#")[1]), [asPath]);
 
-  const renderFaqItems = (faqItems: FaqItem[]) =>
-    faqItems.map(({ title, key, content, subItem }) => (
-      <div
-        className={`${styles.faqItem} ${subItem ? styles.subItem : ""}`}
-        key={key}
-      >
-        <details open={hash === key}>
-          <summary onClick={() => replace("#" + key)}>{title}</summary>
-          {typeof content === "string"
-            ? content
-                .split("\n")
-                .map((contentLine) => <p key={contentLine}>{contentLine}</p>)
-            : content}
-        </details>
-      </div>
-    ));
+  const renderFaqItems = () =>
+    faq?.map(({ question, answer }) => {
+      const key = encodeURIComponent(
+        question.replace(/\s+/g, "-").toLowerCase()
+      );
+      const togglePath = () => replace(hash !== key ? "#" + key : "");
+
+      return (
+        <div className={styles.faqItem} key={key} id={key}>
+          <details open={hash === key}>
+            <summary onClick={togglePath}>{question}</summary>
+            <PortableText value={answer} />
+          </details>
+        </div>
+      );
+    });
 
   return (
     <InfoSectionWrapper>
       <h2 className={styles.title}>FAQ</h2>
-      {renderFaqItems(generalFaqItems)}
+
+      {faq && faq.length > 0 && renderFaqItems()}
+
       <p>
         Lurer du på noe mer? Send en mail til Webkom på{" "}
         <Link href="mailto:webkom@abakus.no">webkom@abakus.no</Link>, så hjelper
@@ -41,96 +45,3 @@ const FaqContent: React.FC = () => {
 };
 
 export default FaqContent;
-
-interface FaqItem {
-  title: string;
-  key: string;
-  content: React.ReactNode;
-  subItem?: boolean;
-}
-
-const generalFaqItems: FaqItem[] = [
-  {
-    title: "Hva er en linjeforening?",
-    key: "linjeforening",
-    content:
-      "En linjeforening er en forening av og for studentene som går ett eller flere studier. I Trondheim finnes det derfor veldig mange forskjellige linjeforeninger - men du forholder deg hovedsakelig kun til den studieretningen din tilhører.",
-  },
-  {
-    title: "Hvordan lage bruker på abakus.no?",
-    key: "lag-bruker",
-    content: (
-      <p>
-        Vi har laget en guide som ligger her;{" "}
-        <Link href="https://www.notion.so/Hvordan-lage-bruker-p-Abakus-no-17be056689194337a1d44865f577d536">
-          hvordan lage bruker på abakus.no
-        </Link>
-      </p>
-    ),
-  },
-  {
-    title: "Pakkeliste til Fadderperioden",
-    key: "pakkeliste",
-    content:
-      "Til Fadderperioden er det en del arrangementer som har tema, som det kan være smart å tenke på før du reiser hjemmefra.\n\n- Hvitt laken uten stretch\n- Outfit til Ops, jeg kom feil\n- Hippieklær\n- Bevegelige klær som tåler å bli våte\n- Dress/Gallakjole\n- Tysk Techno\n- Rød T-skjorte du kan skrive på",
-  },
-  {
-    title: "Kontaktinformasjon",
-    key: "kontakt",
-    content: (
-      <div>
-        <p>
-          Leder av Abakus:
-          <br />
-          Torjus Østensen, 46744072, torjus.ostensen@abakus.no
-        </p>
-        <p>
-          Leder av Arrangementskomiteen til Abakus:
-          <br />
-          Leo Lie McGrath, 407 81 818, leo.mcgrath@abakus.no
-        </p>
-        <p>
-          Ansvarlig for kommunikasjon med faddere og fadderbarn:
-          <br />
-          Andrea Udnæs, 411 31 432, andrea.udnaes@abakus.no
-        </p>
-        <p>
-          Ansvarlig for kommunikasjon med faddere og fadderbarn:
-          <br />
-          Eivind Geiran, 983 04 768, eivind.geiran@abakus.no 
-        </p>
-      </div>
-    ),
-  },
-  {
-    title: "Tips & triks på abakus.no",
-    key: "tips",
-    content: (
-      <div>
-        <h3>Få Abakus-arrangementer rett i kalenderen din</h3>
-        <p>
-          I studielivet skjer det mye rart, og da er det nyttig å ha kontroll på
-          hva som skjer når!
-        </p>
-        <p>
-          Om du går inn på{" "}
-          <Link href="https://abakus.no/events">abakus.no/events</Link> på PC og
-          blar helt nederst på siden, får du alternativene mellom tre mulige
-          kalendere. Enten alle arrangementer, alle registreringstidspunkter
-          (påmeldingstidspunkt) eller dine møter og favorittarrangementer.
-        </p>
-        <p>
-          De to første kan fort bli overvelmende, men den siste inkluderer alle
-          arrangementer der du er påmeldt eller på venteliste, og de du manuelt
-          har lagt til som favoritt (ved å trykke på stjernen ved siden av
-          navnet til arrangementet på abakus.no).
-        </p>
-        <p>
-          Ved å trykke på lenkene kan du enten få kalenderene rett inn i Google
-          Kalender eller hvilken som helst annen kalender som støtter iCalendar
-          (så godt som alle).
-        </p>
-      </div>
-    ),
-  },
-];

--- a/pages/faq.tsx
+++ b/pages/faq.tsx
@@ -1,5 +1,20 @@
 import FaqContent from "@/components/FaqContent";
+import getFAQ from "@/studio/queries/faq";
+import { InferGetStaticPropsType } from "next";
 
-export default function FAQ() {
-  return <FaqContent />;
+type FaqProps = InferGetStaticPropsType<typeof getStaticProps>;
+
+const FAQ = ({ faq }: FaqProps) => {
+  return <FaqContent faq={faq} />;
 }
+
+export async function getStaticProps() {
+  return {
+    props: {
+      faq: await getFAQ(),
+    },
+    revalidate: 60,
+  };
+}
+
+export default FAQ;

--- a/studio/generated/sanity-schema.json
+++ b/studio/generated/sanity-schema.json
@@ -356,6 +356,229 @@
     }
   },
   {
+    "name": "faq",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "faq"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "question": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": false
+      },
+      "answer": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "array",
+          "of": {
+            "type": "object",
+            "attributes": {
+              "children": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "array",
+                  "of": {
+                    "type": "object",
+                    "attributes": {
+                      "marks": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "array",
+                          "of": {
+                            "type": "string"
+                          }
+                        },
+                        "optional": true
+                      },
+                      "text": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "string"
+                        },
+                        "optional": true
+                      },
+                      "_type": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "string",
+                          "value": "span"
+                        }
+                      }
+                    },
+                    "rest": {
+                      "type": "object",
+                      "attributes": {
+                        "_key": {
+                          "type": "objectAttribute",
+                          "value": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "optional": true
+              },
+              "style": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "union",
+                  "of": [
+                    {
+                      "type": "string",
+                      "value": "normal"
+                    },
+                    {
+                      "type": "string",
+                      "value": "h1"
+                    },
+                    {
+                      "type": "string",
+                      "value": "h2"
+                    },
+                    {
+                      "type": "string",
+                      "value": "h3"
+                    },
+                    {
+                      "type": "string",
+                      "value": "h4"
+                    },
+                    {
+                      "type": "string",
+                      "value": "h5"
+                    },
+                    {
+                      "type": "string",
+                      "value": "h6"
+                    },
+                    {
+                      "type": "string",
+                      "value": "blockquote"
+                    }
+                  ]
+                },
+                "optional": true
+              },
+              "listItem": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "union",
+                  "of": [
+                    {
+                      "type": "string",
+                      "value": "bullet"
+                    },
+                    {
+                      "type": "string",
+                      "value": "number"
+                    }
+                  ]
+                },
+                "optional": true
+              },
+              "markDefs": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "array",
+                  "of": {
+                    "type": "object",
+                    "attributes": {
+                      "href": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "string"
+                        },
+                        "optional": true
+                      },
+                      "_type": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "string",
+                          "value": "link"
+                        }
+                      }
+                    },
+                    "rest": {
+                      "type": "object",
+                      "attributes": {
+                        "_key": {
+                          "type": "objectAttribute",
+                          "value": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "optional": true
+              },
+              "level": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "number"
+                },
+                "optional": true
+              },
+              "_type": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string",
+                  "value": "block"
+                }
+              }
+            },
+            "rest": {
+              "type": "object",
+              "attributes": {
+                "_key": {
+                  "type": "objectAttribute",
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "optional": false
+      }
+    }
+  },
+  {
     "name": "taskforce",
     "type": "document",
     "attributes": {

--- a/studio/generated/sanity-schema.json
+++ b/studio/generated/sanity-schema.json
@@ -326,36 +326,6 @@
     }
   },
   {
-    "name": "slug",
-    "type": "type",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "slug"
-          }
-        },
-        "current": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": false
-        },
-        "source": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        }
-      }
-    }
-  },
-  {
     "name": "faq",
     "type": "document",
     "attributes": {
@@ -575,6 +545,44 @@
           }
         },
         "optional": false
+      },
+      "slug": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "slug"
+        },
+        "optional": false
+      }
+    }
+  },
+  {
+    "name": "slug",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "slug"
+          }
+        },
+        "current": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": false
+        },
+        "source": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        }
       }
     }
   },

--- a/studio/generated/sanity.types.ts
+++ b/studio/generated/sanity.types.ts
@@ -74,6 +74,33 @@ export type Slug = {
   source?: string;
 };
 
+export type Faq = {
+  _id: string;
+  _type: "faq";
+  _createdAt: string;
+  _updatedAt: string;
+  _rev: string;
+  question: string;
+  answer: Array<{
+    children?: Array<{
+      marks?: Array<string>;
+      text?: string;
+      _type: "span";
+      _key: string;
+    }>;
+    style?: "normal" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "blockquote";
+    listItem?: "bullet" | "number";
+    markDefs?: Array<{
+      href?: string;
+      _type: "link";
+      _key: string;
+    }>;
+    level?: number;
+    _type: "block";
+    _key: string;
+  }>;
+};
+
 export type Taskforce = {
   _id: string;
   _type: "taskforce";
@@ -229,7 +256,7 @@ export type FpDayDescription = {
   }>;
 };
 
-export type AllSanitySchemaTypes = SanityImagePaletteSwatch | SanityImagePalette | SanityImageDimensions | SanityFileAsset | Geopoint | Slug | Taskforce | SanityImageCrop | SanityImageHotspot | SanityImageAsset | SanityAssetSourceData | SanityImageMetadata | SiteSettings | MfpDayDescription | FpDayDescription;
+export type AllSanitySchemaTypes = SanityImagePaletteSwatch | SanityImagePalette | SanityImageDimensions | SanityFileAsset | Geopoint | Slug | Faq | Taskforce | SanityImageCrop | SanityImageHotspot | SanityImageAsset | SanityAssetSourceData | SanityImageMetadata | SiteSettings | MfpDayDescription | FpDayDescription;
 export declare const internalGroqTypeReferenceTo: unique symbol;
 // Source: ./studio/queries/dayDescriptions.ts
 // Variable: fetchFpDayDescriptions
@@ -270,6 +297,36 @@ export type FetchMfpDayDescriptionsResult = Array<{
   _rev: string;
   date: string;
   content: Array<{
+    children?: Array<{
+      marks?: Array<string>;
+      text?: string;
+      _type: "span";
+      _key: string;
+    }>;
+    style?: "blockquote" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "normal";
+    listItem?: "bullet" | "number";
+    markDefs?: Array<{
+      href?: string;
+      _type: "link";
+      _key: string;
+    }>;
+    level?: number;
+    _type: "block";
+    _key: string;
+  }>;
+}>;
+
+// Source: ./studio/queries/faq.ts
+// Variable: fetchFaq
+// Query: *[_type == "faq"]
+export type FetchFaqResult = Array<{
+  _id: string;
+  _type: "faq";
+  _createdAt: string;
+  _updatedAt: string;
+  _rev: string;
+  question: string;
+  answer: Array<{
     children?: Array<{
       marks?: Array<string>;
       text?: string;
@@ -345,6 +402,7 @@ declare module "@sanity/client" {
   interface SanityQueries {
     "*[_type == \"fpDayDescription\" && date > $startDate] | order(date asc)": FetchFpDayDescriptionsResult;
     "*[_type == \"mfpDayDescription\" && date > $startDate] | order(date asc)": FetchMfpDayDescriptionsResult;
+    "*[_type == \"faq\"]": FetchFaqResult;
     "*[_type == \"siteSettings\"][0]": FetchSiteSettingsResult;
     "*[_type == \"taskforce\"][0]": FetchTaskforceResult;
   }

--- a/studio/generated/sanity.types.ts
+++ b/studio/generated/sanity.types.ts
@@ -68,12 +68,6 @@ export type Geopoint = {
   alt?: number;
 };
 
-export type Slug = {
-  _type: "slug";
-  current: string;
-  source?: string;
-};
-
 export type Faq = {
   _id: string;
   _type: "faq";
@@ -99,6 +93,13 @@ export type Faq = {
     _type: "block";
     _key: string;
   }>;
+  slug: Slug;
+};
+
+export type Slug = {
+  _type: "slug";
+  current: string;
+  source?: string;
 };
 
 export type Taskforce = {
@@ -273,7 +274,7 @@ export type FpDayDescription = {
   }>;
 };
 
-export type AllSanitySchemaTypes = SanityImagePaletteSwatch | SanityImagePalette | SanityImageDimensions | SanityFileAsset | Geopoint | Slug | Faq | Taskforce | SanityImageCrop | SanityImageHotspot | SanityImageAsset | SanityAssetSourceData | SanityImageMetadata | SiteSettings | MfpDayDescription | FpDayDescription;
+export type AllSanitySchemaTypes = SanityImagePaletteSwatch | SanityImagePalette | SanityImageDimensions | SanityFileAsset | Geopoint | Faq | Slug | Taskforce | SanityImageCrop | SanityImageHotspot | SanityImageAsset | SanityAssetSourceData | SanityImageMetadata | SiteSettings | MfpDayDescription | FpDayDescription;
 export declare const internalGroqTypeReferenceTo: unique symbol;
 // Source: ./studio/queries/dayDescriptions.ts
 // Variable: fetchFpDayDescriptions
@@ -361,6 +362,7 @@ export type FetchFaqResult = Array<{
     _type: "block";
     _key: string;
   }>;
+  slug: Slug;
 }>;
 
 // Source: ./studio/queries/settings.ts

--- a/studio/queries/faq.ts
+++ b/studio/queries/faq.ts
@@ -1,0 +1,10 @@
+import { sanityClient } from "./client";
+import { defineQuery } from "next-sanity";
+
+const fetchFaq = defineQuery(`*[_type == "faq"]`);
+
+export async function getFAQ() {
+  return await sanityClient.fetch(fetchFaq);
+}
+
+export default getFAQ;

--- a/studio/schemas/faq.ts
+++ b/studio/schemas/faq.ts
@@ -1,0 +1,41 @@
+import { Rule } from "sanity";
+
+const FAQSchema = {
+  title: "FAQ",
+  name: "faq",
+  type: "document",
+  fields: [
+    {
+      title: "Spørsmål",
+      name: "question",
+      type: "string",
+      validation: (Rule: Rule) => Rule.required(),
+    },
+    {
+      title: "Svar",
+      name: "answer",
+      type: "array",
+      of: [{ type: "block" }],
+      validation: (Rule: Rule) => Rule.required(),
+    }
+  ],
+  preview: {
+    select: {
+      title: "question",
+    },
+  },
+  orderings: [
+    {
+      title: "Spørsmål A-Å",
+      name: "questionAsc",
+      by: [{ field: "question", direction: "asc" }],
+    },
+    {
+      title: "Spørsmål Å-A",
+      name: "questionDesc",
+      by: [{ field: "question", direction: "desc" }],
+    },
+  ],
+};
+
+export default FAQSchema;

--- a/studio/schemas/faq.ts
+++ b/studio/schemas/faq.ts
@@ -9,15 +9,27 @@ const FAQSchema = {
       title: "Spørsmål",
       name: "question",
       type: "string",
-      validation: (Rule: Rule) => Rule.required(),
+      validation: (rule: Rule) => rule.required(),
     },
     {
       title: "Svar",
       name: "answer",
       type: "array",
       of: [{ type: "block" }],
-      validation: (Rule: Rule) => Rule.required(),
-    }
+      validation: (rule: Rule) => rule.required(),
+    },
+    {
+      title: "Slug",
+      description:
+        "En unik identifikator for spørsmålet, til bruk i URL-er. Å endre denne kan medføre at lenker til spørsmålet blir brutt.",
+      name: "slug",
+      type: "slug",
+      options: {
+        source: "question",
+        maxLength: 96,
+      },
+      validation: (rule: Rule) => rule.required(),
+    },
   ],
   preview: {
     select: {

--- a/studio/schemas/index.ts
+++ b/studio/schemas/index.ts
@@ -1,4 +1,5 @@
 import { FPSchema, MFPSchema } from "./dayDescription";
+import FAQSchema from "./faq";
 import SiteSettingsSchema from "./siteSettings";
 import TaskforceSchema from "./taskforce";
 
@@ -7,4 +8,5 @@ export const schemaTypes = [
   MFPSchema,
   SiteSettingsSchema,
   TaskforceSchema,
+  FAQSchema
 ];


### PR DESCRIPTION
- Add faq schema to sanity to be able to manage all faq questions/answers in `/studio`. 
- Update faq page to fetch data from sanity and render as `PortableText` 

Feels like a natural thing to to be able to update through sanity. 